### PR TITLE
[feature] Duration Controller Rest Docs 추가 및 API 문서 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'jacoco'
     id 'com.diffplug.spotless' version '7.0.4'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.halo'
@@ -36,18 +37,22 @@ spotless {
         palantirJavaFormat()
         target 'src/**/*.java'
 
-        importOrder 'java|javax', 'org', ' com.halo.eventer', '', '\\#'
+        importOrder 'java|jakarta', 'org', ' com.halo.eventer', '', '\\#'
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()
     }
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-
+    asciidoctorExt
 }
 
 repositories {
@@ -98,6 +103,10 @@ dependencies {
 
     //prometheus-micrometer
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    //rest docs
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('bootBuildImage') {
@@ -106,4 +115,26 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+tasks.named('asciidoctor') {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn tasks.test
+    baseDirFollowsSourceFile()
+
+    resources {
+        from('src/docs/asciidoc/styles') {
+            into 'styles'
+        }
+    }
+}
+
+bootJar {
+    dependsOn tasks.asciidoctor
+
+    from ("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/src/docs/asciidoc/_attributes.adoc
+++ b/src/docs/asciidoc/_attributes.adoc
@@ -1,0 +1,6 @@
+:linkcss:
+:copycss:
+:docinfodir: {navroot}
+:docinfo: shared
+:stylesdir: {navroot}/styles
+:nofooter:

--- a/src/docs/asciidoc/_nav.adoc
+++ b/src/docs/asciidoc/_nav.adoc
@@ -1,0 +1,8 @@
+xref:{navroot}/index.adoc[pass:[<span class="nav-root">API 문서</span>]]
+
+.기간 (Duration)
+[%collapsible]
+====
+xref:{navroot}/duration/create-duration.adoc[duration 생성] +
+xref:{navroot}/duration/get-durations.adoc[duration 전체 조회]
+====

--- a/src/docs/asciidoc/common/unauthenticated.adoc
+++ b/src/docs/asciidoc/common/unauthenticated.adoc
@@ -1,0 +1,5 @@
+=== 인증 오류 (401 Unauthenticated)
+
+
+include::{snippets}/common/unauthenticated/response-body.adoc[]
+include::{snippets}/common/unauthenticated/response-fields.adoc[]

--- a/src/docs/asciidoc/docinfo.html
+++ b/src/docs/asciidoc/docinfo.html
@@ -1,0 +1,18 @@
+<link rel="stylesheet" href="/docs/styles/docs.css">
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+
+        const currentPath = location.pathname;
+
+        document.querySelectorAll('.api-nav a').forEach(link => {
+            const linkPath = new URL(link.getAttribute('href'), location.href)
+                .pathname.replace(/\/$/, '');
+            if (currentPath === linkPath) {
+                for (let el = link.parentElement; el; el = el.parentElement) {
+                    if (el.tagName === 'DETAILS') el.open = true;
+                }
+            }
+        });
+    });
+</script>

--- a/src/docs/asciidoc/duration/create-duration.adoc
+++ b/src/docs/asciidoc/duration/create-duration.adoc
@@ -10,8 +10,15 @@ endif::[]
 
 
 
-== 축제 기간 생성 API {sp} `POST /duration`
+== 축제 기간 생성 API `POST /duration`
 
 '''
 
 operation::duration/create-duration[snippets="http-request,request-headers,query-parameters,request-fields,http-response"]
+
+'''
+
+
+=== Error
+
+include::{navroot}/common/unauthenticated.adoc[]

--- a/src/docs/asciidoc/duration/create-duration.adoc
+++ b/src/docs/asciidoc/duration/create-duration.adoc
@@ -1,0 +1,17 @@
+:navroot: ..
+include::../_attributes.adoc[]
+
+ifdef::backend-html5[]
+[role="api-nav"]
+****
+include::{navroot}/_nav.adoc[]
+****
+endif::[]
+
+
+
+== 축제 기간 생성 API {sp} `POST /duration`
+
+'''
+
+operation::duration/create-duration[snippets="http-request,request-headers,query-parameters,request-fields,http-response"]

--- a/src/docs/asciidoc/duration/get-durations.adoc
+++ b/src/docs/asciidoc/duration/get-durations.adoc
@@ -1,0 +1,17 @@
+:navroot: ..
+include::../_attributes.adoc[]
+
+ifdef::backend-html5[]
+[role="api-nav"]
+****
+include::{navroot}/_nav.adoc[]
+****
+endif::[]
+
+
+
+== 축제 기간 전체 조회 API {sp} `GET /duration`
+
+'''
+
+operation::duration/get-durations[snippets="http-request,query-parameters,response-fields,http-response"]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,24 @@
+:navroot: .
+include::_attributes.adoc[]
+
+= Festimap 플랫폼 API 문서
+:revnumber: v1.0
+:revdate: {localdatetime}
+
+ifdef::backend-html5[]
+[role="api-nav"]
+****
+include::{navroot}/_nav.adoc[]
+****
+endif::[]
+
+
+== Duration
+
+[cols="1,1,2",options="header"]
+|===
+| 도메인 | 메서드 | 기능
+
+| duration | POST /duration       | Duration **생성**
+| duration | GET  /durations       | Duration **목록 조회**
+|===

--- a/src/docs/asciidoc/styles/docs.css
+++ b/src/docs/asciidoc/styles/docs.css
@@ -1,0 +1,21 @@
+/* 왼쪽 네비게이션 */
+.sidebarblock.api-nav{
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 260px;
+    margin: 0;
+    padding: 1rem 1.2rem 1rem;;
+    overflow-y: auto;
+    background: #fafafa;
+    border-right: 1px solid #ddd;
+    z-index: 1000;
+}
+
+#header,#content{ margin-left: 280px; }
+
+.sidebarblock.api-nav .nav-root{
+    font-size: 21px;
+    font-weight: 600;
+}

--- a/src/main/java/com/halo/eventer/EventerApplication.java
+++ b/src/main/java/com/halo/eventer/EventerApplication.java
@@ -1,11 +1,10 @@
 package com.halo.eventer;
 
 import java.util.TimeZone;
+import jakarta.annotation.PostConstruct;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-import jakarta.annotation.PostConstruct;
 
 @SpringBootApplication
 public class EventerApplication {

--- a/src/main/java/com/halo/eventer/domain/duration/Duration.java
+++ b/src/main/java/com/halo/eventer/domain/duration/Duration.java
@@ -3,10 +3,10 @@ package com.halo.eventer.domain.duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.duration.dto.DurationCreateDto;
 import com.halo.eventer.domain.festival.Festival;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/duration/DurationMap.java
+++ b/src/main/java/com/halo/eventer/domain/duration/DurationMap.java
@@ -1,7 +1,8 @@
 package com.halo.eventer.domain.duration;
 
-import com.halo.eventer.domain.map.Map;
 import jakarta.persistence.*;
+
+import com.halo.eventer.domain.map.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/duration/dto/DurationCreateDto.java
+++ b/src/main/java/com/halo/eventer/domain/duration/dto/DurationCreateDto.java
@@ -14,8 +14,8 @@ public class DurationCreateDto {
     private Integer dayNumber;
 
     @Builder
-    public DurationCreateDto(LocalDate date, Integer day) {
+    public DurationCreateDto(LocalDate date, Integer dayNumber) {
         this.date = date;
-        this.dayNumber = day;
+        this.dayNumber = dayNumber;
     }
 }

--- a/src/main/java/com/halo/eventer/domain/duration/dto/DurationResDto.java
+++ b/src/main/java/com/halo/eventer/domain/duration/dto/DurationResDto.java
@@ -16,12 +16,12 @@ public class DurationResDto {
 
     private Long durationId;
     private LocalDate date;
-    private Integer day;
+    private Integer dayNumber;
 
     public DurationResDto(Duration duration) {
         this.durationId = duration.getId();
         this.date = duration.getDate();
-        this.day = duration.getDayNumber();
+        this.dayNumber = duration.getDayNumber();
     }
 
     public static List<DurationResDto> fromDurations(List<Duration> durations) {

--- a/src/main/java/com/halo/eventer/domain/festival/Festival.java
+++ b/src/main/java/com/halo/eventer/domain/festival/Festival.java
@@ -2,6 +2,7 @@ package com.halo.eventer.domain.festival;
 
 import java.util.ArrayList;
 import java.util.List;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.duration.Duration;
 import com.halo.eventer.domain.festival.dto.*;
@@ -15,7 +16,6 @@ import com.halo.eventer.domain.notice.Notice;
 import com.halo.eventer.domain.splash.Splash;
 import com.halo.eventer.domain.stamp.Stamp;
 import com.halo.eventer.domain.widget.BaseWidget;
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/image/Image.java
+++ b/src/main/java/com/halo/eventer/domain/image/Image.java
@@ -1,8 +1,9 @@
 package com.halo.eventer.domain.image;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.notice.Notice;
 import com.halo.eventer.domain.widget_item.WidgetItem;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/inquiry/Inquiry.java
+++ b/src/main/java/com/halo/eventer/domain/inquiry/Inquiry.java
@@ -1,6 +1,7 @@
 package com.halo.eventer.domain.inquiry;
 
 import java.time.LocalDateTime;
+import jakarta.persistence.*;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -8,7 +9,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.inquiry.dto.InquiryCreateReqDto;
 import com.halo.eventer.domain.inquiry.dto.InquiryUserReqDto;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/halo/eventer/domain/inquiry/controller/InquiryController.java
@@ -1,10 +1,11 @@
 package com.halo.eventer.domain.inquiry.controller;
 
+import jakarta.validation.constraints.Min;
+
 import org.springframework.web.bind.annotation.*;
 
 import com.halo.eventer.domain.inquiry.dto.*;
 import com.halo.eventer.domain.inquiry.service.InquiryService;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/com/halo/eventer/domain/lost_item/LostItem.java
+++ b/src/main/java/com/halo/eventer/domain/lost_item/LostItem.java
@@ -1,10 +1,10 @@
 package com.halo.eventer.domain.lost_item;
 
 import java.time.LocalDate;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.lost_item.dto.LostItemReqDto;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/manager/Manager.java
+++ b/src/main/java/com/halo/eventer/domain/manager/Manager.java
@@ -1,7 +1,8 @@
 package com.halo.eventer.domain.manager;
 
-import com.halo.eventer.domain.festival.Festival;
 import jakarta.persistence.*;
+
+import com.halo.eventer.domain.festival.Festival;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/manager/dto/ManagerResDto.java
+++ b/src/main/java/com/halo/eventer/domain/manager/dto/ManagerResDto.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ManagerResDto {
+
     private Long id;
     private String phoneNo;
 

--- a/src/main/java/com/halo/eventer/domain/map/Map.java
+++ b/src/main/java/com/halo/eventer/domain/map/Map.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.duration.Duration;
 import com.halo.eventer.domain.duration.DurationMap;
@@ -12,7 +13,6 @@ import com.halo.eventer.domain.map.dto.map.MapUpdateDto;
 import com.halo.eventer.domain.map.embedded.ButtonInfo;
 import com.halo.eventer.domain.map.embedded.LocationInfo;
 import com.halo.eventer.domain.map.embedded.OperationInfo;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/map/MapCategory.java
+++ b/src/main/java/com/halo/eventer/domain/map/MapCategory.java
@@ -2,13 +2,13 @@ package com.halo.eventer.domain.map;
 
 import java.util.ArrayList;
 import java.util.List;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.map.dto.mapcategory.MapCategoryImageDto;
 import com.halo.eventer.domain.map.enumtype.MapCategoryType;
 import com.halo.eventer.domain.widget.entity.DisplayOrderUpdatable;
 import com.halo.eventer.global.constants.DisplayOrderConstants;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/map/Menu.java
+++ b/src/main/java/com/halo/eventer/domain/map/Menu.java
@@ -1,8 +1,9 @@
 package com.halo.eventer.domain.map;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.map.dto.menu.MenuCreateDto;
 import com.halo.eventer.domain.map.dto.menu.MenuUpdateDto;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/map/embedded/ButtonInfo.java
+++ b/src/main/java/com/halo/eventer/domain/map/embedded/ButtonInfo.java
@@ -1,7 +1,8 @@
 package com.halo.eventer.domain.map.embedded;
 
-import com.halo.eventer.domain.map.dto.map.ButtonInfoDto;
 import jakarta.persistence.Embeddable;
+
+import com.halo.eventer.domain.map.dto.map.ButtonInfoDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/map/embedded/LocationInfo.java
+++ b/src/main/java/com/halo/eventer/domain/map/embedded/LocationInfo.java
@@ -1,7 +1,8 @@
 package com.halo.eventer.domain.map.embedded;
 
-import com.halo.eventer.domain.map.dto.map.LocationInfoDto;
 import jakarta.persistence.Embeddable;
+
+import com.halo.eventer.domain.map.dto.map.LocationInfoDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/map/embedded/OperationInfo.java
+++ b/src/main/java/com/halo/eventer/domain/map/embedded/OperationInfo.java
@@ -1,10 +1,11 @@
 package com.halo.eventer.domain.map.embedded;
 
-import com.halo.eventer.domain.map.dto.map.OperationInfoDto;
-import com.halo.eventer.domain.map.enumtype.OperationTime;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+
+import com.halo.eventer.domain.map.dto.map.OperationInfoDto;
+import com.halo.eventer.domain.map.enumtype.OperationTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/member/Authority.java
+++ b/src/main/java/com/halo/eventer/domain/member/Authority.java
@@ -1,7 +1,8 @@
 package com.halo.eventer.domain.member;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/member/Member.java
+++ b/src/main/java/com/halo/eventer/domain/member/Member.java
@@ -2,8 +2,8 @@ package com.halo.eventer.domain.member;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
 import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/missing_person/MissingPerson.java
+++ b/src/main/java/com/halo/eventer/domain/missing_person/MissingPerson.java
@@ -1,8 +1,9 @@
 package com.halo.eventer.domain.missing_person;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.missing_person.dto.MissingPersonReqDto;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/notice/Notice.java
+++ b/src/main/java/com/halo/eventer/domain/notice/Notice.java
@@ -1,6 +1,7 @@
 package com.halo.eventer.domain.notice;
 
 import java.util.*;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.image.Image;
@@ -9,7 +10,6 @@ import com.halo.eventer.domain.notice.dto.NoticeUpdateReqDto;
 import com.halo.eventer.domain.notice.exception.MissingNoticeException;
 import com.halo.eventer.global.common.BaseTime;
 import com.halo.eventer.global.constants.DisplayOrderConstants;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/halo/eventer/domain/notice/controller/admin/AdminNoticeController.java
+++ b/src/main/java/com/halo/eventer/domain/notice/controller/admin/AdminNoticeController.java
@@ -1,6 +1,8 @@
 package com.halo.eventer.domain.notice.controller.admin;
 
 import java.util.List;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 import org.springframework.web.bind.annotation.*;
 
@@ -8,8 +10,6 @@ import com.halo.eventer.domain.notice.ArticleType;
 import com.halo.eventer.domain.notice.dto.*;
 import com.halo.eventer.domain.notice.service.NoticeService;
 import com.halo.eventer.global.common.page.PagedResponse;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/com/halo/eventer/domain/notice/dto/user/UserNoticePageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/notice/dto/user/UserNoticePageReqDto.java
@@ -1,11 +1,11 @@
 package com.halo.eventer.domain.notice.dto.user;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/com/halo/eventer/domain/splash/Splash.java
+++ b/src/main/java/com/halo/eventer/domain/splash/Splash.java
@@ -1,7 +1,8 @@
 package com.halo.eventer.domain.splash;
 
-import com.halo.eventer.domain.festival.Festival;
 import jakarta.persistence.*;
+
+import com.halo.eventer.domain.festival.Festival;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/Custom.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/Custom.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/Mission.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/Mission.java
@@ -1,8 +1,9 @@
 package com.halo.eventer.domain.stamp;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.stamp.dto.mission.MissionUpdateDto;
 import com.halo.eventer.domain.stamp.dto.stamp.MissionSetDto;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/stamp/Stamp.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/Stamp.java
@@ -3,10 +3,10 @@ package com.halo.eventer.domain.stamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.stamp.exception.StampClosedException;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/StampUser.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/StampUser.java
@@ -3,9 +3,9 @@ package com.halo.eventer.domain.stamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.stamp.exception.UserMissionNotFoundException;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/UserMission.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/UserMission.java
@@ -1,6 +1,7 @@
 package com.halo.eventer.domain.stamp;
 
 import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/widget/BaseWidget.java
+++ b/src/main/java/com/halo/eventer/domain/widget/BaseWidget.java
@@ -2,13 +2,13 @@ package com.halo.eventer.domain.widget;
 
 import java.util.ArrayList;
 import java.util.List;
+import jakarta.persistence.*;
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.widget_item.WidgetItem;
 import com.halo.eventer.global.common.BaseTime;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/widget/controller/MiddleWidgetController.java
+++ b/src/main/java/com/halo/eventer/domain/widget/controller/MiddleWidgetController.java
@@ -1,6 +1,8 @@
 package com.halo.eventer.domain.widget.controller;
 
 import java.util.List;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -11,8 +13,6 @@ import com.halo.eventer.global.common.dto.OrderUpdateRequest;
 import com.halo.eventer.global.common.page.PagedResponse;
 import com.halo.eventer.global.common.sort.SortOption;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/com/halo/eventer/domain/widget/controller/SquareWidgetController.java
+++ b/src/main/java/com/halo/eventer/domain/widget/controller/SquareWidgetController.java
@@ -1,6 +1,8 @@
 package com.halo.eventer.domain.widget.controller;
 
 import java.util.List;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -12,8 +14,6 @@ import com.halo.eventer.global.common.dto.OrderUpdateRequest;
 import com.halo.eventer.global.common.page.PagedResponse;
 import com.halo.eventer.global.common.sort.SortOption;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/com/halo/eventer/domain/widget/controller/UpWidgetController.java
+++ b/src/main/java/com/halo/eventer/domain/widget/controller/UpWidgetController.java
@@ -2,6 +2,8 @@ package com.halo.eventer.domain.widget.controller;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
@@ -13,8 +15,6 @@ import com.halo.eventer.domain.widget.service.UpWidgetService;
 import com.halo.eventer.global.common.page.PagedResponse;
 import com.halo.eventer.global.common.sort.SortOption;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController

--- a/src/main/java/com/halo/eventer/domain/widget/entity/DownWidget.java
+++ b/src/main/java/com/halo/eventer/domain/widget/entity/DownWidget.java
@@ -1,11 +1,12 @@
 package com.halo.eventer.domain.widget.entity;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.widget.BaseWidget;
 import com.halo.eventer.domain.widget.dto.down_widget.DownWidgetCreateDto;
 import com.halo.eventer.domain.widget.feature.DisplayOrderFeature;
 import com.halo.eventer.global.constants.DisplayOrderConstants;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/widget/entity/MainWidget.java
+++ b/src/main/java/com/halo/eventer/domain/widget/entity/MainWidget.java
@@ -1,11 +1,12 @@
 package com.halo.eventer.domain.widget.entity;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.widget.BaseWidget;
 import com.halo.eventer.domain.widget.dto.main_widget.MainWidgetCreateDto;
 import com.halo.eventer.domain.widget.feature.DescriptionFeature;
 import com.halo.eventer.domain.widget.feature.ImageFeature;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/widget/entity/MiddleWidget.java
+++ b/src/main/java/com/halo/eventer/domain/widget/entity/MiddleWidget.java
@@ -1,12 +1,13 @@
 package com.halo.eventer.domain.widget.entity;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.widget.BaseWidget;
 import com.halo.eventer.domain.widget.dto.middle_widget.MiddleWidgetCreateDto;
 import com.halo.eventer.domain.widget.feature.DisplayOrderFeature;
 import com.halo.eventer.domain.widget.feature.ImageFeature;
 import com.halo.eventer.global.constants.DisplayOrderConstants;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/widget/entity/SquareWidget.java
+++ b/src/main/java/com/halo/eventer/domain/widget/entity/SquareWidget.java
@@ -1,5 +1,7 @@
 package com.halo.eventer.domain.widget.entity;
 
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.widget.BaseWidget;
 import com.halo.eventer.domain.widget.dto.square_widget.SquareWidgetCreateDto;
@@ -7,7 +9,6 @@ import com.halo.eventer.domain.widget.feature.DescriptionFeature;
 import com.halo.eventer.domain.widget.feature.DisplayOrderFeature;
 import com.halo.eventer.domain.widget.feature.ImageFeature;
 import com.halo.eventer.global.constants.DisplayOrderConstants;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/widget/entity/UpWidget.java
+++ b/src/main/java/com/halo/eventer/domain/widget/entity/UpWidget.java
@@ -1,12 +1,12 @@
 package com.halo.eventer.domain.widget.entity;
 
 import java.time.LocalDateTime;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.widget.BaseWidget;
 import com.halo.eventer.domain.widget.dto.up_widget.UpWidgetCreateDto;
 import com.halo.eventer.domain.widget.feature.PeriodFeature;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/domain/widget/feature/DescriptionFeature.java
+++ b/src/main/java/com/halo/eventer/domain/widget/feature/DescriptionFeature.java
@@ -2,6 +2,7 @@ package com.halo.eventer.domain.widget.feature;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/widget/feature/DisplayOrderFeature.java
+++ b/src/main/java/com/halo/eventer/domain/widget/feature/DisplayOrderFeature.java
@@ -2,6 +2,7 @@ package com.halo.eventer.domain.widget.feature;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/widget/feature/ImageFeature.java
+++ b/src/main/java/com/halo/eventer/domain/widget/feature/ImageFeature.java
@@ -2,6 +2,7 @@ package com.halo.eventer.domain.widget.feature;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/widget/feature/PeriodFeature.java
+++ b/src/main/java/com/halo/eventer/domain/widget/feature/PeriodFeature.java
@@ -1,9 +1,9 @@
 package com.halo.eventer.domain.widget.feature;
 
 import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/widget_item/WidgetItem.java
+++ b/src/main/java/com/halo/eventer/domain/widget_item/WidgetItem.java
@@ -2,11 +2,11 @@ package com.halo.eventer.domain.widget_item;
 
 import java.util.ArrayList;
 import java.util.List;
+import jakarta.persistence.*;
 
 import com.halo.eventer.domain.image.Image;
 import com.halo.eventer.domain.widget.BaseWidget;
 import com.halo.eventer.domain.widget_item.dto.WidgetItemCreateDto;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/halo/eventer/global/common/BaseTime.java
+++ b/src/main/java/com/halo/eventer/global/common/BaseTime.java
@@ -1,14 +1,14 @@
 package com.halo.eventer.global.common;
 
 import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
+++ b/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
@@ -3,7 +3,9 @@ package com.halo.eventer.global.constants;
 public class SecurityConstants {
 
     // 공개 API 경로
-    public static final String[] SWAGGER_URLS = {"/", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/test"};
+    public static final String[] SWAGGER_URLS = {
+        "/", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/docs/**"
+    };
 
     public static final String[] PUBLIC_GET_URLS = {
         "/concert",

--- a/src/main/java/com/halo/eventer/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/halo/eventer/global/error/GlobalExceptionHandler.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.halo.eventer.global.error.exception.BaseException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -64,6 +66,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        log.error("Exception Occurred", e);
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(response);
     }

--- a/src/main/java/com/halo/eventer/global/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/halo/eventer/global/security/exception/CustomAccessDeniedHandler.java
@@ -1,15 +1,15 @@
 package com.halo.eventer.global.security.exception;
 
 import java.io.IOException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import com.halo.eventer.global.error.ErrorCode;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {

--- a/src/main/java/com/halo/eventer/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/halo/eventer/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,15 +1,15 @@
 package com.halo.eventer.global.security.exception;
 
 import java.io.IOException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import com.halo.eventer.global.error.ErrorCode;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/src/main/java/com/halo/eventer/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/halo/eventer/global/security/filter/JwtAuthenticationFilter.java
@@ -1,16 +1,16 @@
 package com.halo.eventer.global.security.filter;
 
 import java.io.IOException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.halo.eventer.global.security.provider.JwtProvider;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;

--- a/src/main/java/com/halo/eventer/global/security/filter/SecurityExceptionFilter.java
+++ b/src/main/java/com/halo/eventer/global/security/filter/SecurityExceptionFilter.java
@@ -1,15 +1,15 @@
 package com.halo.eventer.global.security.filter;
 
 import java.io.IOException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import com.halo.eventer.global.error.exception.BaseException;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public class SecurityExceptionFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/halo/eventer/global/security/provider/JwtProvider.java
+++ b/src/main/java/com/halo/eventer/global/security/provider/JwtProvider.java
@@ -3,6 +3,8 @@ package com.halo.eventer.global.security.provider;
 import java.security.Key;
 import java.util.Date;
 import java.util.List;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,8 +20,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import jakarta.servlet.http.HttpServletRequest;
 
 @Component
 public class JwtProvider {

--- a/src/test/java/com/halo/eventer/domain/duration/DurationFixture.java
+++ b/src/test/java/com/halo/eventer/domain/duration/DurationFixture.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import com.halo.eventer.domain.duration.dto.DurationCreateDto;
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.festival.FestivalFixture;
-import com.halo.eventer.domain.map.Map;
 
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -16,24 +15,28 @@ public class DurationFixture {
     public static final int 기본_DAY = 1;
 
     public static DurationCreateDto 기본_Duration_생성_DTO() {
-        return DurationCreateDto.builder().date(기본_DATE).day(기본_DAY).build();
+        return DurationCreateDto.builder().date(기본_DATE).dayNumber(기본_DAY).build();
     }
 
-    public static DurationCreateDto 커스텀_Duration_생성_DTO(LocalDate date, int dayNumber) {
-        return DurationCreateDto.builder().date(date).day(dayNumber).build();
-    }
-
-    public static Duration Duration_엔티티() {
+    public static Duration 축제_첫째_날() {
         Festival festival = FestivalFixture.축제_엔티티();
-        DurationCreateDto durationCreateDto = 기본_Duration_생성_DTO();
+        DurationCreateDto durationCreateDto = DurationCreateDto.builder()
+                .date(LocalDate.of(2025, 1, 1))
+                .dayNumber(1)
+                .build();
         Duration duration = Duration.of(festival, durationCreateDto);
         setField(duration, "id", 1L);
         return duration;
     }
 
-    public static DurationMap DurationMap_엔티티(Map map, Duration duration) {
-        DurationMap durationMap = DurationMap.of(duration, map);
-        setField(durationMap, "id", 1L);
-        return durationMap;
+    public static Duration 축제_둘째_날() {
+        Festival festival = FestivalFixture.축제_엔티티();
+        DurationCreateDto durationCreateDto = DurationCreateDto.builder()
+                .date(LocalDate.of(2025, 1, 2))
+                .dayNumber(2)
+                .build();
+        Duration duration = Duration.of(festival, durationCreateDto);
+        setField(duration, "id", 2L);
+        return duration;
     }
 }

--- a/src/test/java/com/halo/eventer/domain/duration/api_docs/DurationDoc.java
+++ b/src/test/java/com/halo/eventer/domain/duration/api_docs/DurationDoc.java
@@ -41,4 +41,14 @@ public class DurationDoc {
                                 .type(JsonFieldType.NUMBER)
                                 .description("축제 시작일 기준 N번째 날 (1부터 시작)")));
     }
+
+    public static RestDocumentationResultHandler unauthenticated(){
+        return document("common/unauthenticated",
+                responseFields(
+                        fieldWithPath("code").description("에러 코드 번호"),
+                        fieldWithPath("message").description("상세 에러 메시지"),
+                        fieldWithPath("status").description("HTTP 상태 코드")
+                )
+        );
+    }
 }

--- a/src/test/java/com/halo/eventer/domain/duration/api_docs/DurationDoc.java
+++ b/src/test/java/com/halo/eventer/domain/duration/api_docs/DurationDoc.java
@@ -1,0 +1,44 @@
+package com.halo.eventer.domain.duration.api_docs;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+public class DurationDoc {
+
+    public static RestDocumentationResultHandler createDuration() {
+        return document(
+                "duration/create-duration",
+                requestHeaders(headerWithName("Authorization").description("JWT Access 토큰")),
+                queryParameters(parameterWithName("festivalId")
+                        .description("축제 id")
+                        .attributes(key("constraints").value("필수, 1 이상의 양의 정수"))),
+                requestFields(
+                        fieldWithPath("[].date").type(JsonFieldType.STRING).description("축제 날짜"),
+                        fieldWithPath("[].dayNumber").type(JsonFieldType.NUMBER).description("축제 일차 (n일차)")));
+    }
+
+    public static RestDocumentationResultHandler getDurations() {
+        return document(
+                "duration/get-durations",
+                queryParameters(parameterWithName("festivalId")
+                        .description("축제 id")
+                        .attributes(key("constraints").value("필수, 1 이상의 양의 정수"))),
+                responseFields(
+                        fieldWithPath("[]").description("기간(Duration) 목록"),
+                        fieldWithPath("[].durationId")
+                                .type(JsonFieldType.NUMBER)
+                                .description("기간 식별자(ID)"),
+                        fieldWithPath("[].date").type(JsonFieldType.STRING).description("해당 기간 날짜 (yyyy-MM-dd)"),
+                        fieldWithPath("[].dayNumber")
+                                .type(JsonFieldType.NUMBER)
+                                .description("축제 시작일 기준 N번째 날 (1부터 시작)")));
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/duration/api_docs/DurationDoc.java
+++ b/src/test/java/com/halo/eventer/domain/duration/api_docs/DurationDoc.java
@@ -42,13 +42,12 @@ public class DurationDoc {
                                 .description("축제 시작일 기준 N번째 날 (1부터 시작)")));
     }
 
-    public static RestDocumentationResultHandler unauthenticated(){
-        return document("common/unauthenticated",
+    public static RestDocumentationResultHandler unauthenticated() {
+        return document(
+                "common/unauthenticated",
                 responseFields(
                         fieldWithPath("code").description("에러 코드 번호"),
                         fieldWithPath("message").description("상세 에러 메시지"),
-                        fieldWithPath("status").description("HTTP 상태 코드")
-                )
-        );
+                        fieldWithPath("status").description("HTTP 상태 코드")));
     }
 }

--- a/src/test/java/com/halo/eventer/domain/duration/controller/DurationControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/duration/controller/DurationControllerTest.java
@@ -83,15 +83,16 @@ public class DurationControllerTest {
 
     @Test
     void 일반유저_축제기간_생성_인증거부() throws Exception {
-        // given
-        doNothing().when(durationService).createDurations(any(), any());
-
         // when & then
         mockMvc.perform(post("/duration")
                         .param("festivalId", "1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(durationCreateDtos)))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("code").value("A002"))
+                .andExpect(jsonPath("message").value("Unauthenticated"))
+                .andExpect(jsonPath("status").value(401))
+                .andDo(DurationDoc.unauthenticated());
     }
 
     @Test

--- a/src/test/java/com/halo/eventer/domain/duration/controller/DurationControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/duration/controller/DurationControllerTest.java
@@ -6,9 +6,11 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -16,10 +18,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.duration.DurationFixture;
+import com.halo.eventer.domain.duration.api_docs.DurationDoc;
 import com.halo.eventer.domain.duration.dto.DurationCreateDto;
 import com.halo.eventer.domain.duration.dto.DurationResDto;
 import com.halo.eventer.domain.duration.service.DurationService;
 import com.halo.eventer.global.config.ControllerTestSecurityBeans;
+import com.halo.eventer.global.config.CustomRestDocsConfig;
 import com.halo.eventer.global.config.security.SecurityConfig;
 import com.halo.eventer.global.security.provider.JwtProvider;
 
@@ -33,9 +38,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(DurationController.class)
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 @SuppressWarnings("NonAsciiCharacters")
 @ActiveProfiles("test")
-@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class, CustomRestDocsConfig.class})
 public class DurationControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -51,13 +57,11 @@ public class DurationControllerTest {
 
     private final Long festivalId = 1L;
     List<DurationCreateDto> durationCreateDtos;
-    List<DurationResDto> durationResDtos;
 
     @BeforeEach
     void setUp() {
         durationCreateDtos = List.of(
-                new DurationCreateDto(LocalDate.of(2025, 3, 1), 3), new DurationCreateDto(LocalDate.of(2025, 3, 5), 2));
-        durationResDtos = List.of(new DurationResDto());
+                new DurationCreateDto(LocalDate.of(2025, 1, 1), 1), new DurationCreateDto(LocalDate.of(2025, 1, 2), 2));
     }
 
     @Test
@@ -68,10 +72,12 @@ public class DurationControllerTest {
 
         // when & then
         mockMvc.perform(post("/duration")
-                        .param("festivalId", "1")
+                        .queryParam("festivalId", "1")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {access-token}")
                         .content(objectMapper.writeValueAsString(durationCreateDtos)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andDo(DurationDoc.createDuration());
         verify(durationService, times(1)).createDurations(any(), any());
     }
 
@@ -91,11 +97,21 @@ public class DurationControllerTest {
     @Test
     void 축제기간_리스트_조회() throws Exception {
         // given
+        DurationResDto res1 = new DurationResDto(DurationFixture.축제_첫째_날());
+        DurationResDto res2 = new DurationResDto(DurationFixture.축제_둘째_날());
+        List<DurationResDto> durationResDtos = List.of(res1, res2);
         given(durationService.getDurations(any())).willReturn(durationResDtos);
 
         // when & then
         mockMvc.perform(get("/duration").param("festivalId", "1").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(1));
+                .andExpect(jsonPath("$.length()").value(durationResDtos.size()))
+                .andExpect(jsonPath("$[0].durationId").value("1"))
+                .andExpect(jsonPath("$[0].date").value("2025-01-01"))
+                .andExpect(jsonPath("$[0].dayNumber").value(1))
+                .andExpect(jsonPath("$[1].durationId").value("2"))
+                .andExpect(jsonPath("$[1].date").value("2025-01-02"))
+                .andExpect(jsonPath("$[1].dayNumber").value(2))
+                .andDo(DurationDoc.getDurations());
     }
 }

--- a/src/test/java/com/halo/eventer/domain/duration/entity/DurationMapTest.java
+++ b/src/test/java/com/halo/eventer/domain/duration/entity/DurationMapTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class DurationMapTest {
-    private Duration duration = DurationFixture.Duration_엔티티();
+    private Duration duration = DurationFixture.축제_첫째_날();
     private Map map = MapFixture.기본_지도_엔티티();
 
     @Test

--- a/src/test/java/com/halo/eventer/domain/duration/service/DurationServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/duration/service/DurationServiceTest.java
@@ -106,6 +106,6 @@ public class DurationServiceTest {
         // then
         assertThat(targets.size()).isEqualTo(1);
         assertThat(targets.get(0).getDate()).isEqualTo("2025-03-02");
-        assertThat(targets.get(0).getDay()).isEqualTo(3);
+        assertThat(targets.get(0).getDayNumber()).isEqualTo(3);
     }
 }

--- a/src/test/java/com/halo/eventer/global/config/CustomRestDocsConfig.java
+++ b/src/test/java/com/halo/eventer/global/config/CustomRestDocsConfig.java
@@ -1,0 +1,16 @@
+package com.halo.eventer.global.config;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentationConfigurer;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@TestConfiguration
+public class CustomRestDocsConfig implements RestDocsMockMvcConfigurationCustomizer {
+
+    @Override
+    public void customize(MockMvcRestDocumentationConfigurer configurer) {
+        configurer.operationPreprocessors().withRequestDefaults(prettyPrint()).withResponseDefaults(prettyPrint());
+    }
+}

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
@@ -1,0 +1,9 @@
+|===
+|Parameter|Description|Constraints
+
+{{#parameters}}
+|{{name}}
+|{{description}}
+|{{constraints}}
+{{/parameters}}
+|===


### PR DESCRIPTION
## #️⃣연관된 이슈

- #126 

## 📝작업 내용

1. Rest Docs 설정 Build.gradle에 추가
2. Controller 테스트에 Rest docs 관련 코드 추가
3. adoc 문법 기반 API 문서 관련 파일 추가

<br>

## 참고 사항 (작성 법)

1. Rest Docs 스니펫을 생성하기 위한 코드는 따로 <도메인>DOc 클래스를 생성해서 해당 위치에 작성한다. 이렇게 진행하면 테스트코드와 API 문서 코드를 분리해서 관리할 수 있다.

2. 사용하는 스니펫에서 제공하는 기본 UI 템플릿으로 불가능할 경우 test/resources/org/springframework/restdocs/templates/asciidoctor에 해당 템플릿 명으로 새로 파일 생성
-> Rest docs의 템플릿 코드 참고하기

3. docs/asciidoc에 adoc 파일 작성
index.adoc -> 표 형식으로 도메인 별 API 개요 작성
_nav.adoc -> 왼쪽 side-bar에 새로 추가하는 도메인의 경우 Duration을 보고 참고하여 추가하기
도메인/메서드명 구조로 adoc 파일 생성
adoc 파일의 기본 형식은 아래와 같이 작성한다.
```
// 기본 설정 추가
:navroot: ..
include::../_attributes.adoc[]

// side-bar 추가
ifdef::backend-html5[]
[role="api-nav"]
****
include::{navroot}/_nav.adoc[]
****
endif::[]


// 스니펫 이용하여 api 문서 구성
== 축제 기간 생성 API `POST /duration`

'''

operation::duration/create-duration[snippets="http-request,request-headers,query-parameters,request-fields,http-response"]

'''

// 나올 수 있는 Error 포함시키기
=== Error

include::{navroot}/common/unauthenticated.adoc[]
```

<br>

+@
아래 명령어로는 문서 접근 불가 -> 현재 bootJar Task에만 adoc파일을 html로 변환한 문서를 포함시키도록 구성
```
./gradlew run
```

따라서, API 문서를 모두 작성하고 실제 동작을 확인하려면 run task에 추가하거나 다음과 같은 명령어를 이용하여 확인할 수 있다.

```
./gradlew clean build
java -jar .\build\libs\eventer-0.0.1-SNAPSHOT.jar
```

<br>

## 스크린샷

`메인 화면`
![image](https://github.com/user-attachments/assets/534d94c6-4e0a-4aba-ace5-78d920dd7308)

`Duration 관련 API 문서`
![image](https://github.com/user-attachments/assets/c49c8bd2-a4c4-4061-9c11-802649a876db)




