### PR TITLE
주차 관리 시스템 ( 기본정보, 지도 이미지) 관련 기능 구현

### DIFF
--- a/src/main/java/com/halo/eventer/domain/festival/Festival.java
+++ b/src/main/java/com/halo/eventer/domain/festival/Festival.java
@@ -2,6 +2,9 @@ package com.halo.eventer.domain.festival;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.parking.enums.ParkingInfoType;
 import jakarta.persistence.*;
 
 import com.halo.eventer.domain.duration.Duration;
@@ -75,6 +78,9 @@ public class Festival {
 
     @OneToMany(mappedBy = "festival", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<MissingPerson> missingPersons = new ArrayList<>();
+
+    @OneToMany(mappedBy = "festival", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<ParkingManagement> parkingManagements = new ArrayList<>();
 
     private Festival(String name, String subAddress) {
         this.name = name;

--- a/src/main/java/com/halo/eventer/domain/festival/Festival.java
+++ b/src/main/java/com/halo/eventer/domain/festival/Festival.java
@@ -2,9 +2,6 @@ package com.halo.eventer.domain.festival;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import com.halo.eventer.domain.parking.ParkingManagement;
-import com.halo.eventer.domain.parking.enums.ParkingInfoType;
 import jakarta.persistence.*;
 
 import com.halo.eventer.domain.duration.Duration;
@@ -16,6 +13,7 @@ import com.halo.eventer.domain.manager.Manager;
 import com.halo.eventer.domain.map.MapCategory;
 import com.halo.eventer.domain.missing_person.MissingPerson;
 import com.halo.eventer.domain.notice.Notice;
+import com.halo.eventer.domain.parking.ParkingManagement;
 import com.halo.eventer.domain.splash.Splash;
 import com.halo.eventer.domain.stamp.Stamp;
 import com.halo.eventer.domain.widget.BaseWidget;

--- a/src/main/java/com/halo/eventer/domain/image/Image.java
+++ b/src/main/java/com/halo/eventer/domain/image/Image.java
@@ -1,9 +1,13 @@
 package com.halo.eventer.domain.image;
 
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.widget.entity.DisplayOrderUpdatable;
+import com.halo.eventer.global.constants.DisplayOrderConstants;
 import jakarta.persistence.*;
 
 import com.halo.eventer.domain.notice.Notice;
 import com.halo.eventer.domain.widget_item.WidgetItem;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,17 +30,37 @@ public class Image {
     @JoinColumn(name = "widget_item_id")
     private WidgetItem widgetItem;
 
-    private Image(String imageUrl, Notice notice, WidgetItem widgetItem) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parking_management_id")
+    private ParkingManagement parkingManagement;
+
+    @Builder
+    private Image(String imageUrl, Notice notice, WidgetItem widgetItem, ParkingManagement parkingManagement) {
         this.imageUrl = imageUrl;
         this.notice = notice;
         this.widgetItem = widgetItem;
+        this.parkingManagement = parkingManagement;
     }
 
     public static Image ofNotice(String imageUrl, Notice notice) {
-        return new Image(imageUrl, notice, null);
+        return Image.builder()
+                .imageUrl(imageUrl)
+                .notice(notice)
+                .build();
     }
 
     public static Image ofWidgetItem(String imageUrl, WidgetItem widgetItem) {
-        return new Image(imageUrl, null, widgetItem);
+        return Image.builder()
+                .imageUrl(imageUrl)
+                .widgetItem(widgetItem)
+                .build();
     }
+
+    public static Image ofParkingManagement(String imageUrl, ParkingManagement parkingManagement) {
+        return Image.builder()
+                .imageUrl(imageUrl)
+                .parkingManagement(parkingManagement)
+                .build();
+    }
+
 }

--- a/src/main/java/com/halo/eventer/domain/image/Image.java
+++ b/src/main/java/com/halo/eventer/domain/image/Image.java
@@ -1,11 +1,9 @@
 package com.halo.eventer.domain.image;
 
-import com.halo.eventer.domain.parking.ParkingManagement;
-import com.halo.eventer.domain.widget.entity.DisplayOrderUpdatable;
-import com.halo.eventer.global.constants.DisplayOrderConstants;
 import jakarta.persistence.*;
 
 import com.halo.eventer.domain.notice.Notice;
+import com.halo.eventer.domain.parking.ParkingManagement;
 import com.halo.eventer.domain.widget_item.WidgetItem;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,17 +41,11 @@ public class Image {
     }
 
     public static Image ofNotice(String imageUrl, Notice notice) {
-        return Image.builder()
-                .imageUrl(imageUrl)
-                .notice(notice)
-                .build();
+        return Image.builder().imageUrl(imageUrl).notice(notice).build();
     }
 
     public static Image ofWidgetItem(String imageUrl, WidgetItem widgetItem) {
-        return Image.builder()
-                .imageUrl(imageUrl)
-                .widgetItem(widgetItem)
-                .build();
+        return Image.builder().imageUrl(imageUrl).widgetItem(widgetItem).build();
     }
 
     public static Image ofParkingManagement(String imageUrl, ParkingManagement parkingManagement) {
@@ -62,5 +54,4 @@ public class Image {
                 .parkingManagement(parkingManagement)
                 .build();
     }
-
 }

--- a/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
@@ -1,18 +1,18 @@
 package com.halo.eventer.domain.parking;
 
+import java.util.*;
+import java.util.stream.Collectors;
+import jakarta.persistence.*;
+
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.image.Image;
 import com.halo.eventer.domain.parking.enums.ParkingInfoType;
 import com.halo.eventer.global.constants.DisplayOrderConstants;
 import com.halo.eventer.global.error.ErrorCode;
 import com.halo.eventer.global.error.exception.BaseException;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -60,7 +60,16 @@ public class ParkingManagement {
     @OneToMany(mappedBy = "parkingManagement", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
-    private ParkingManagement(Festival festival, String headerName, ParkingInfoType parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
+    private ParkingManagement(
+            Festival festival,
+            String headerName,
+            ParkingInfoType parkingInfoType,
+            String title,
+            String description,
+            String buttonName,
+            String buttonTargetUrl,
+            String backgroundImage,
+            boolean visible) {
         this.festival = festival;
         this.headerName = headerName;
         this.parkingInfoType = parkingInfoType;
@@ -72,13 +81,39 @@ public class ParkingManagement {
         this.visible = visible;
     }
 
-    public static ParkingManagement of(Festival festival, String headerName, ParkingInfoType parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible){
-        ParkingManagement parkingManagement = new ParkingManagement(festival, headerName, parkingInfoType, title, description, buttonName, buttonTargetUrl, backgroundImage, visible);
+    public static ParkingManagement of(
+            Festival festival,
+            String headerName,
+            ParkingInfoType parkingInfoType,
+            String title,
+            String description,
+            String buttonName,
+            String buttonTargetUrl,
+            String backgroundImage,
+            boolean visible) {
+        ParkingManagement parkingManagement = new ParkingManagement(
+                festival,
+                headerName,
+                parkingInfoType,
+                title,
+                description,
+                buttonName,
+                buttonTargetUrl,
+                backgroundImage,
+                visible);
         festival.getParkingManagements().add(parkingManagement);
         return parkingManagement;
     }
 
-    public void update(String headerName, ParkingInfoType parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible){
+    public void update(
+            String headerName,
+            ParkingInfoType parkingInfoType,
+            String title,
+            String description,
+            String buttonName,
+            String buttonTargetUrl,
+            String backgroundImage,
+            boolean visible) {
         this.headerName = headerName;
         this.parkingInfoType = parkingInfoType;
         this.title = title;
@@ -89,17 +124,17 @@ public class ParkingManagement {
         this.visible = visible;
     }
 
-    public void updateSubPageHeaderName(String subPageHeaderName){
+    public void updateSubPageHeaderName(String subPageHeaderName) {
         this.subPageHeaderName = subPageHeaderName;
     }
 
-    public void addImage(String imageUrl){
+    public void addImage(String imageUrl) {
         validateImageCount();
         Image image = Image.ofParkingManagement(imageUrl, this);
         images.add(image);
     }
 
-    public void reorderImages(List<Long> orderedIds){
+    public void reorderImages(List<Long> orderedIds) {
         validateReorderIdsDuplicationAndSize(orderedIds);
         validateNoMissingIds(orderedIds);
 
@@ -110,27 +145,29 @@ public class ParkingManagement {
         images.sort(Comparator.comparingInt((Image img) -> rank.get(img.getId())));
     }
 
-    public void removeImages(List<Long> imageIds){
+    public void removeImages(List<Long> imageIds) {
         Set<Long> removdIds = new HashSet<>(imageIds);
         images.removeIf(image -> removdIds.contains(image.getId()));
     }
 
-    private void validateReorderIdsDuplicationAndSize(List<Long> orderedIds){
+    private void validateReorderIdsDuplicationAndSize(List<Long> orderedIds) {
         Set<Long> targets = new HashSet<>(orderedIds);
-        if(targets.size() != orderedIds.size() || targets.size() != images.size()){
+        if (targets.size() != orderedIds.size() || targets.size() != images.size()) {
             throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
+
     private void validateNoMissingIds(List<Long> orderedIds) {
         Set<Long> existingIds = images.stream().map(Image::getId).collect(Collectors.toSet());
-        List<Long> unknown = orderedIds.stream().filter(id -> !existingIds.contains(id)).toList();
+        List<Long> unknown =
+                orderedIds.stream().filter(id -> !existingIds.contains(id)).toList();
         if (!unknown.isEmpty()) {
             throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
 
-    private void validateImageCount(){
-        if(images.size() >= DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE){
+    private void validateImageCount() {
+        if (images.size() >= DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE) {
             throw new BaseException(ErrorCode.MAX_COUNT_EXCEEDED);
         }
     }

--- a/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
@@ -1,0 +1,137 @@
+package com.halo.eventer.domain.parking;
+
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.image.Image;
+import com.halo.eventer.domain.parking.enums.ParkingInfoType;
+import com.halo.eventer.global.constants.DisplayOrderConstants;
+import com.halo.eventer.global.error.ErrorCode;
+import com.halo.eventer.global.error.exception.BaseException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "parking_management")
+public class ParkingManagement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "header_name", nullable = false, length = 10)
+    private String headerName;
+
+    @Column(name = "parking_info_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ParkingInfoType parkingInfoType;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", nullable = true)
+    private String description;
+
+    @Column(name = "button_name", nullable = false)
+    private String buttonName;
+
+    @Column(name = "button_target_url", nullable = true)
+    private String buttonTargetUrl;
+
+    @Column(name = "background_image", nullable = true)
+    private String backgroundImage;
+
+    @Column(name = "sub_page_header_name", nullable = true)
+    private String subPageHeaderName;
+
+    @Column(name = "visible", nullable = false)
+    private boolean visible = true;
+
+    @ManyToOne
+    @JoinColumn(name = "festival_id")
+    private Festival festival;
+
+    @OrderColumn(name = "display_order")
+    @OneToMany(mappedBy = "parkingManagement", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> images = new ArrayList<>();
+
+    private ParkingManagement(Festival festival, String headerName, ParkingInfoType parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
+        this.festival = festival;
+        this.headerName = headerName;
+        this.parkingInfoType = parkingInfoType;
+        this.title = title;
+        this.description = description;
+        this.buttonName = buttonName;
+        this.buttonTargetUrl = buttonTargetUrl;
+        this.backgroundImage = backgroundImage;
+        this.visible = visible;
+    }
+
+    public static ParkingManagement of(Festival festival, String headerName, ParkingInfoType parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible){
+        ParkingManagement parkingManagement = new ParkingManagement(festival, headerName, parkingInfoType, title, description, buttonName, buttonTargetUrl, backgroundImage, visible);
+        festival.getParkingManagements().add(parkingManagement);
+        return parkingManagement;
+    }
+
+    public void update(String headerName, ParkingInfoType parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible){
+        this.headerName = headerName;
+        this.parkingInfoType = parkingInfoType;
+        this.title = title;
+        this.description = description;
+        this.buttonName = buttonName;
+        this.buttonTargetUrl = buttonTargetUrl;
+        this.backgroundImage = backgroundImage;
+        this.visible = visible;
+    }
+
+    public void updateSubPageHeaderName(String subPageHeaderName){
+        this.subPageHeaderName = subPageHeaderName;
+    }
+
+    public void addImage(String imageUrl){
+        validateImageCount();
+        Image image = Image.ofParkingManagement(imageUrl, this);
+        images.add(image);
+    }
+
+    public void reorderImages(List<Long> orderedIds){
+        validateReorderIdsDuplicationAndSize(orderedIds);
+        validateNoMissingIds(orderedIds);
+
+        Map<Long, Integer> rank = new HashMap<>();
+        for (int i = 0; i < orderedIds.size(); i++) {
+            rank.put(orderedIds.get(i), i);
+        }
+        images.sort(Comparator.comparingInt((Image img) -> rank.get(img.getId())));
+    }
+
+    public void removeImages(List<Long> imageIds){
+        Set<Long> removdIds = new HashSet<>(imageIds);
+        images.removeIf(image -> removdIds.contains(image.getId()));
+    }
+
+    private void validateReorderIdsDuplicationAndSize(List<Long> orderedIds){
+        Set<Long> targets = new HashSet<>(orderedIds);
+        if(targets.size() != orderedIds.size() || targets.size() != images.size()){
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+    private void validateNoMissingIds(List<Long> orderedIds) {
+        Set<Long> existingIds = images.stream().map(Image::getId).collect(Collectors.toSet());
+        List<Long> unknown = orderedIds.stream().filter(id -> !existingIds.contains(id)).toList();
+        if (!unknown.isEmpty()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateImageCount(){
+        if(images.size() >= DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE){
+            throw new BaseException(ErrorCode.MAX_COUNT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/controller/ParkingManagementController.java
+++ b/src/main/java/com/halo/eventer/domain/parking/controller/ParkingManagementController.java
@@ -1,12 +1,14 @@
 package com.halo.eventer.domain.parking.controller;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+
+import org.springframework.web.bind.annotation.*;
+
 import com.halo.eventer.domain.image.dto.FileDto;
 import com.halo.eventer.domain.parking.dto.*;
 import com.halo.eventer.domain.parking.service.ParkingManagementService;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,46 +18,49 @@ public class ParkingManagementController {
     private final ParkingManagementService parkingManagementService;
 
     @PostMapping("/admin/festivals/{festivalId}/parking-managements")
-    public void create(@Min(1) @PathVariable("festivalId") Long festivalId,
-                       @Valid @RequestBody ParkingManagementReqDto parkingManagementReqDto){
+    public void create(
+            @Min(1) @PathVariable("festivalId") Long festivalId,
+            @Valid @RequestBody ParkingManagementReqDto parkingManagementReqDto) {
         parkingManagementService.create(festivalId, parkingManagementReqDto);
     }
 
     @GetMapping("/common/parking-managements/{id}")
-    public ParkingManagementResDto getParkingManagement(@PathVariable("id") Long id){
+    public ParkingManagementResDto getParkingManagement(@PathVariable("id") Long id) {
         return parkingManagementService.getParkingManagement(id);
     }
 
     @PutMapping("/admin/parking-managements/{id}")
-    public void update(@Min(1) @PathVariable("id") Long id,
-                       @Valid @RequestBody ParkingManagementReqDto parkingManagementReqDto){
-        parkingManagementService.update(id,parkingManagementReqDto);
+    public void update(
+            @Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingManagementReqDto parkingManagementReqDto) {
+        parkingManagementService.update(id, parkingManagementReqDto);
     }
 
     @GetMapping("/admin/parking-managements/{id}/sub-page-info")
-    public ParkingManagementSubPageResDto getParkingManagementByFestivalIdAndParkingInfoType(@PathVariable("id") Long id){
+    public ParkingManagementSubPageResDto getParkingManagementByFestivalIdAndParkingInfoType(
+            @PathVariable("id") Long id) {
         return parkingManagementService.getParkingManagementSubPage(id);
     }
 
     @PatchMapping("/admin/parking-managements/{id}/sub-page-header-name")
-    public void updateSubPageHeaderName(@Min(1) @PathVariable("id") Long id,
-                                        @Valid @RequestBody ParkingSubPageReqDto parkingSubPageReqDto){
+    public void updateSubPageHeaderName(
+            @Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingSubPageReqDto parkingSubPageReqDto) {
         parkingManagementService.updateSubPageHeaderName(id, parkingSubPageReqDto);
     }
 
     @PostMapping("/admin/parking-managements/{id}/parking-map-images")
-    public void createParkingMapImage(@Min(1) @PathVariable("id") Long id, @RequestBody FileDto fileDto){
+    public void createParkingMapImage(@Min(1) @PathVariable("id") Long id, @RequestBody FileDto fileDto) {
         parkingManagementService.createParkingMapImage(id, fileDto);
     }
 
     @PatchMapping("/admin/parking-managements/{id}/parking-map-images/display-order")
-    public void updateParkingMapImageDisplayOrder(@Min(1) @PathVariable("id") Long id,
-                                                  @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto){
-        parkingManagementService.updateParkingMapImageDisplayOrder(id,parkingMapImageReqDto);
+    public void updateParkingMapImageDisplayOrder(
+            @Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto) {
+        parkingManagementService.updateParkingMapImageDisplayOrder(id, parkingMapImageReqDto);
     }
 
     @DeleteMapping("/admin/parking-managements/{id}/parking-map-images")
-    public void deleteParkingMapImages(@Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto){
+    public void deleteParkingMapImages(
+            @Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto) {
         parkingManagementService.deleteParkingMapImages(id, parkingMapImageReqDto);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/parking/controller/ParkingManagementController.java
+++ b/src/main/java/com/halo/eventer/domain/parking/controller/ParkingManagementController.java
@@ -1,0 +1,61 @@
+package com.halo.eventer.domain.parking.controller;
+
+import com.halo.eventer.domain.image.dto.FileDto;
+import com.halo.eventer.domain.parking.dto.*;
+import com.halo.eventer.domain.parking.service.ParkingManagementService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2")
+public class ParkingManagementController {
+
+    private final ParkingManagementService parkingManagementService;
+
+    @PostMapping("/admin/festivals/{festivalId}/parking-managements")
+    public void create(@Min(1) @PathVariable("festivalId") Long festivalId,
+                       @Valid @RequestBody ParkingManagementReqDto parkingManagementReqDto){
+        parkingManagementService.create(festivalId, parkingManagementReqDto);
+    }
+
+    @GetMapping("/common/parking-managements/{id}")
+    public ParkingManagementResDto getParkingManagement(@PathVariable("id") Long id){
+        return parkingManagementService.getParkingManagement(id);
+    }
+
+    @PutMapping("/admin/parking-managements/{id}")
+    public void update(@Min(1) @PathVariable("id") Long id,
+                       @Valid @RequestBody ParkingManagementReqDto parkingManagementReqDto){
+        parkingManagementService.update(id,parkingManagementReqDto);
+    }
+
+    @GetMapping("/admin/parking-managements/{id}/sub-page-info")
+    public ParkingManagementSubPageResDto getParkingManagementByFestivalIdAndParkingInfoType(@PathVariable("id") Long id){
+        return parkingManagementService.getParkingManagementSubPage(id);
+    }
+
+    @PatchMapping("/admin/parking-managements/{id}/sub-page-header-name")
+    public void updateSubPageHeaderName(@Min(1) @PathVariable("id") Long id,
+                                        @Valid @RequestBody ParkingSubPageReqDto parkingSubPageReqDto){
+        parkingManagementService.updateSubPageHeaderName(id, parkingSubPageReqDto);
+    }
+
+    @PostMapping("/admin/parking-managements/{id}/parking-map-images")
+    public void createParkingMapImage(@Min(1) @PathVariable("id") Long id, @RequestBody FileDto fileDto){
+        parkingManagementService.createParkingMapImage(id, fileDto);
+    }
+
+    @PatchMapping("/admin/parking-managements/{id}/parking-map-images/display-order")
+    public void updateParkingMapImageDisplayOrder(@Min(1) @PathVariable("id") Long id,
+                                                  @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto){
+        parkingManagementService.updateParkingMapImageDisplayOrder(id,parkingMapImageReqDto);
+    }
+
+    @DeleteMapping("/admin/parking-managements/{id}/parking-map-images")
+    public void deleteParkingMapImages(@Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto){
+        parkingManagementService.deleteParkingMapImages(id, parkingMapImageReqDto);
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementReqDto.java
@@ -2,6 +2,7 @@ package com.halo.eventer.domain.parking.dto;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +13,7 @@ public class ParkingManagementReqDto {
     private String headerName;
 
     @NotNull
-    @Pattern(regexp = "BASIC|BUTTON|SIMPLE",
-            message = "parkingInfoType must be one of: BASIC, BUTTON, SIMPLE")
+    @Pattern(regexp = "BASIC|BUTTON|SIMPLE", message = "parkingInfoType must be one of: BASIC, BUTTON, SIMPLE")
     private String parkingInfoType;
 
     private String title;
@@ -26,7 +26,15 @@ public class ParkingManagementReqDto {
     private boolean visible;
 
     @Builder
-    public ParkingManagementReqDto(String headerName, String parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
+    public ParkingManagementReqDto(
+            String headerName,
+            String parkingInfoType,
+            String title,
+            String description,
+            String buttonName,
+            String buttonTargetUrl,
+            String backgroundImage,
+            boolean visible) {
         this.headerName = headerName;
         this.parkingInfoType = parkingInfoType;
         this.title = title;

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementReqDto.java
@@ -1,0 +1,39 @@
+package com.halo.eventer.domain.parking.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingManagementReqDto {
+    private String headerName;
+
+    @NotNull
+    @Pattern(regexp = "BASIC|BUTTON|SIMPLE",
+            message = "parkingInfoType must be one of: BASIC, BUTTON, SIMPLE")
+    private String parkingInfoType;
+
+    private String title;
+    private String description;
+    private String buttonName;
+    private String buttonTargetUrl;
+    private String backgroundImage;
+
+    @NotNull
+    private boolean visible;
+
+    @Builder
+    public ParkingManagementReqDto(String headerName, String parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
+        this.headerName = headerName;
+        this.parkingInfoType = parkingInfoType;
+        this.title = title;
+        this.description = description;
+        this.buttonName = buttonName;
+        this.buttonTargetUrl = buttonTargetUrl;
+        this.backgroundImage = backgroundImage;
+        this.visible = visible;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementResDto.java
@@ -1,0 +1,32 @@
+package com.halo.eventer.domain.parking.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingManagementResDto {
+    private String headerName;
+    private String parkingInfoType;
+    private String title;
+    private String description;
+    private String buttonName;
+    private String buttonTargetUrl;
+    private String backgroundImage;
+    private boolean visible;
+
+    private ParkingManagementResDto(String headerName, String parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
+        this.headerName = headerName;
+        this.parkingInfoType = parkingInfoType;
+        this.title = title;
+        this.description = description;
+        this.buttonName = buttonName;
+        this.buttonTargetUrl = buttonTargetUrl;
+        this.backgroundImage = backgroundImage;
+        this.visible = visible;
+    }
+
+    public static ParkingManagementResDto of(String headerName, String parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
+        return new ParkingManagementResDto(headerName, parkingInfoType, title, description, buttonName, buttonTargetUrl, backgroundImage, visible);
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementResDto.java
@@ -15,7 +15,15 @@ public class ParkingManagementResDto {
     private String backgroundImage;
     private boolean visible;
 
-    private ParkingManagementResDto(String headerName, String parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
+    private ParkingManagementResDto(
+            String headerName,
+            String parkingInfoType,
+            String title,
+            String description,
+            String buttonName,
+            String buttonTargetUrl,
+            String backgroundImage,
+            boolean visible) {
         this.headerName = headerName;
         this.parkingInfoType = parkingInfoType;
         this.title = title;
@@ -26,7 +34,16 @@ public class ParkingManagementResDto {
         this.visible = visible;
     }
 
-    public static ParkingManagementResDto of(String headerName, String parkingInfoType, String title, String description, String buttonName, String buttonTargetUrl, String backgroundImage, boolean visible) {
-        return new ParkingManagementResDto(headerName, parkingInfoType, title, description, buttonName, buttonTargetUrl, backgroundImage, visible);
+    public static ParkingManagementResDto of(
+            String headerName,
+            String parkingInfoType,
+            String title,
+            String description,
+            String buttonName,
+            String buttonTargetUrl,
+            String backgroundImage,
+            boolean visible) {
+        return new ParkingManagementResDto(
+                headerName, parkingInfoType, title, description, buttonName, buttonTargetUrl, backgroundImage, visible);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementSubPageResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementSubPageResDto.java
@@ -1,11 +1,11 @@
 package com.halo.eventer.domain.parking.dto;
 
+import java.util.List;
+
 import com.halo.eventer.domain.image.Image;
 import com.halo.eventer.domain.image.dto.ImageDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementSubPageResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingManagementSubPageResDto.java
@@ -1,0 +1,20 @@
+package com.halo.eventer.domain.parking.dto;
+
+import com.halo.eventer.domain.image.Image;
+import com.halo.eventer.domain.image.dto.ImageDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ParkingManagementSubPageResDto {
+    private String subPageHeaderName;
+    private List<ImageDto> images;
+
+    public ParkingManagementSubPageResDto(String subPageHeaderName, List<Image> images) {
+        this.subPageHeaderName = subPageHeaderName;
+        this.images = images.stream().map(ImageDto::from).toList();
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingMapImageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingMapImageReqDto.java
@@ -1,14 +1,14 @@
 package com.halo.eventer.domain.parking.dto;
 
+import java.util.List;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
 public class ParkingMapImageReqDto {
-    private @NotNull List<@Min(1)Long> imageIds;
+    private @NotNull List<@Min(1) Long> imageIds;
 }

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingMapImageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingMapImageReqDto.java
@@ -1,0 +1,14 @@
+package com.halo.eventer.domain.parking.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ParkingMapImageReqDto {
+    private @NotNull List<@Min(1)Long> imageIds;
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingSubPageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingSubPageReqDto.java
@@ -1,6 +1,7 @@
 package com.halo.eventer.domain.parking.dto;
 
 import jakarta.validation.constraints.NotNull;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/halo/eventer/domain/parking/dto/ParkingSubPageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/ParkingSubPageReqDto.java
@@ -1,0 +1,17 @@
+package com.halo.eventer.domain.parking.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingSubPageReqDto {
+
+    @NotNull
+    private String subPageHeaderName;
+
+    public ParkingSubPageReqDto(String subPageHeaderName) {
+        this.subPageHeaderName = subPageHeaderName;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/enums/ParkingInfoType.java
+++ b/src/main/java/com/halo/eventer/domain/parking/enums/ParkingInfoType.java
@@ -1,0 +1,7 @@
+package com.halo.eventer.domain.parking.enums;
+
+public enum ParkingInfoType {
+    BASIC,
+    BUTTON,
+    SIMPLE
+}

--- a/src/main/java/com/halo/eventer/domain/parking/exception/ParkingManagementNotFoundException.java
+++ b/src/main/java/com/halo/eventer/domain/parking/exception/ParkingManagementNotFoundException.java
@@ -1,0 +1,9 @@
+package com.halo.eventer.domain.parking.exception;
+
+import com.halo.eventer.global.error.exception.EntityNotFoundException;
+
+public class ParkingManagementNotFoundException extends EntityNotFoundException {
+    public ParkingManagementNotFoundException(Long id) {
+        super(String.format("ParkingManagement with %d is not found", id));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/repository/ParkingManagementRepository.java
+++ b/src/main/java/com/halo/eventer/domain/parking/repository/ParkingManagementRepository.java
@@ -1,0 +1,18 @@
+package com.halo.eventer.domain.parking.repository;
+
+import com.halo.eventer.domain.parking.ParkingManagement;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ParkingManagementRepository extends JpaRepository<ParkingManagement, Long> {
+
+    @Query("SELECT pm FROM ParkingManagement pm JOIN FETCH pm.images i WHERE pm.id = :id ")
+    Optional<ParkingManagement> findByIdWithImages(@Param("id") Long id);
+}

--- a/src/main/java/com/halo/eventer/domain/parking/repository/ParkingManagementRepository.java
+++ b/src/main/java/com/halo/eventer/domain/parking/repository/ParkingManagementRepository.java
@@ -1,15 +1,12 @@
 package com.halo.eventer.domain.parking.repository;
 
-import com.halo.eventer.domain.parking.ParkingManagement;
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.QueryHint;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import com.halo.eventer.domain.parking.ParkingManagement;
 
 public interface ParkingManagementRepository extends JpaRepository<ParkingManagement, Long> {
 

--- a/src/main/java/com/halo/eventer/domain/parking/service/ParkingManagementService.java
+++ b/src/main/java/com/halo/eventer/domain/parking/service/ParkingManagementService.java
@@ -1,0 +1,82 @@
+package com.halo.eventer.domain.parking.service;
+
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.festival.exception.FestivalNotFoundException;
+import com.halo.eventer.domain.festival.repository.FestivalRepository;
+import com.halo.eventer.domain.image.dto.FileDto;
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.parking.dto.*;
+import com.halo.eventer.domain.parking.enums.ParkingInfoType;
+import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
+import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ParkingManagementService {
+
+    private final ParkingManagementRepository parkingManagementRepository;
+    private final FestivalRepository festivalRepository;
+
+    @Transactional
+    public void create(Long festivalId, ParkingManagementReqDto parkingManagementReqDto){
+        Festival festival = festivalRepository.findById(festivalId)
+                .orElseThrow(() -> new FestivalNotFoundException(festivalId));
+
+        ParkingManagement parkingManagement = ParkingManagement.of(festival, parkingManagementReqDto.getHeaderName(), ParkingInfoType.valueOf(parkingManagementReqDto.getParkingInfoType()), parkingManagementReqDto.getTitle(), parkingManagementReqDto.getDescription(),parkingManagementReqDto.getButtonName(),parkingManagementReqDto.getButtonTargetUrl(),parkingManagementReqDto.getBackgroundImage(), parkingManagementReqDto.isVisible());
+        parkingManagementRepository.save(parkingManagement);
+    }
+
+    @Transactional(readOnly = true)
+    public ParkingManagementResDto getParkingManagement(Long id){
+        ParkingManagement parkingManagement = parkingManagementRepository.findById(id)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(id));
+        return ParkingManagementResDto.of(parkingManagement.getHeaderName(),parkingManagement.getParkingInfoType().name(),parkingManagement.getTitle(),parkingManagement.getDescription(),parkingManagement.getButtonName(),parkingManagement.getButtonTargetUrl(),parkingManagement.getBackgroundImage(),parkingManagement.isVisible());
+    }
+
+    @Transactional
+    public void update(Long id, ParkingManagementReqDto parkingManagementReqDto){
+        ParkingManagement parkingManagement = loadParkingManagementOrThrow(id);
+        parkingManagement.update(parkingManagementReqDto.getHeaderName(), ParkingInfoType.valueOf(parkingManagementReqDto.getParkingInfoType()),parkingManagementReqDto.getTitle(),parkingManagementReqDto.getDescription(),parkingManagementReqDto.getButtonName(),parkingManagementReqDto.getButtonTargetUrl(),parkingManagementReqDto.getBackgroundImage(), parkingManagementReqDto.isVisible());
+    }
+
+    @Transactional(readOnly = true)
+    public ParkingManagementSubPageResDto getParkingManagementSubPage(Long id){
+        ParkingManagement parkingManagement = parkingManagementRepository.findByIdWithImages(id)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(id));
+        return new ParkingManagementSubPageResDto(parkingManagement.getSubPageHeaderName(),parkingManagement.getImages());
+    }
+
+    @Transactional
+    public void updateSubPageHeaderName(Long id, ParkingSubPageReqDto parkingSubPageReqDto){
+        ParkingManagement parkingManagement = loadParkingManagementOrThrow(id);
+        parkingManagement.updateSubPageHeaderName(parkingSubPageReqDto.getSubPageHeaderName());
+    }
+
+    @Transactional
+    public void createParkingMapImage(Long id, FileDto fileDto){
+        ParkingManagement parkingManagement = loadParkingManagementOrThrow(id);
+        parkingManagement.addImage(fileDto.getUrl());
+    }
+
+    @Transactional
+    public void updateParkingMapImageDisplayOrder(Long id, ParkingMapImageReqDto parkingMapImageReqDto){
+        ParkingManagement parkingManagement = parkingManagementRepository.findByIdWithImages(id)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(id));
+
+        parkingManagement.reorderImages(parkingMapImageReqDto.getImageIds());
+    }
+
+    @Transactional
+    public void deleteParkingMapImages(Long id, ParkingMapImageReqDto parkingMapImageReqDto){
+        ParkingManagement parkingManagement = parkingManagementRepository.findByIdWithImages(id)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(id));
+        parkingManagement.removeImages(parkingMapImageReqDto.getImageIds());
+    }
+
+    private ParkingManagement loadParkingManagementOrThrow(Long id) {
+        return parkingManagementRepository.findById(id).orElseThrow(() -> new ParkingManagementNotFoundException(id));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/service/ParkingManagementService.java
+++ b/src/main/java/com/halo/eventer/domain/parking/service/ParkingManagementService.java
@@ -1,5 +1,8 @@
 package com.halo.eventer.domain.parking.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.festival.exception.FestivalNotFoundException;
 import com.halo.eventer.domain.festival.repository.FestivalRepository;
@@ -10,8 +13,6 @@ import com.halo.eventer.domain.parking.enums.ParkingInfoType;
 import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
 import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,57 +22,86 @@ public class ParkingManagementService {
     private final FestivalRepository festivalRepository;
 
     @Transactional
-    public void create(Long festivalId, ParkingManagementReqDto parkingManagementReqDto){
-        Festival festival = festivalRepository.findById(festivalId)
-                .orElseThrow(() -> new FestivalNotFoundException(festivalId));
+    public void create(Long festivalId, ParkingManagementReqDto parkingManagementReqDto) {
+        Festival festival =
+                festivalRepository.findById(festivalId).orElseThrow(() -> new FestivalNotFoundException(festivalId));
 
-        ParkingManagement parkingManagement = ParkingManagement.of(festival, parkingManagementReqDto.getHeaderName(), ParkingInfoType.valueOf(parkingManagementReqDto.getParkingInfoType()), parkingManagementReqDto.getTitle(), parkingManagementReqDto.getDescription(),parkingManagementReqDto.getButtonName(),parkingManagementReqDto.getButtonTargetUrl(),parkingManagementReqDto.getBackgroundImage(), parkingManagementReqDto.isVisible());
+        ParkingManagement parkingManagement = ParkingManagement.of(
+                festival,
+                parkingManagementReqDto.getHeaderName(),
+                ParkingInfoType.valueOf(parkingManagementReqDto.getParkingInfoType()),
+                parkingManagementReqDto.getTitle(),
+                parkingManagementReqDto.getDescription(),
+                parkingManagementReqDto.getButtonName(),
+                parkingManagementReqDto.getButtonTargetUrl(),
+                parkingManagementReqDto.getBackgroundImage(),
+                parkingManagementReqDto.isVisible());
         parkingManagementRepository.save(parkingManagement);
     }
 
     @Transactional(readOnly = true)
-    public ParkingManagementResDto getParkingManagement(Long id){
-        ParkingManagement parkingManagement = parkingManagementRepository.findById(id)
-                .orElseThrow(() -> new ParkingManagementNotFoundException(id));
-        return ParkingManagementResDto.of(parkingManagement.getHeaderName(),parkingManagement.getParkingInfoType().name(),parkingManagement.getTitle(),parkingManagement.getDescription(),parkingManagement.getButtonName(),parkingManagement.getButtonTargetUrl(),parkingManagement.getBackgroundImage(),parkingManagement.isVisible());
+    public ParkingManagementResDto getParkingManagement(Long id) {
+        ParkingManagement parkingManagement =
+                parkingManagementRepository.findById(id).orElseThrow(() -> new ParkingManagementNotFoundException(id));
+        return ParkingManagementResDto.of(
+                parkingManagement.getHeaderName(),
+                parkingManagement.getParkingInfoType().name(),
+                parkingManagement.getTitle(),
+                parkingManagement.getDescription(),
+                parkingManagement.getButtonName(),
+                parkingManagement.getButtonTargetUrl(),
+                parkingManagement.getBackgroundImage(),
+                parkingManagement.isVisible());
     }
 
     @Transactional
-    public void update(Long id, ParkingManagementReqDto parkingManagementReqDto){
+    public void update(Long id, ParkingManagementReqDto parkingManagementReqDto) {
         ParkingManagement parkingManagement = loadParkingManagementOrThrow(id);
-        parkingManagement.update(parkingManagementReqDto.getHeaderName(), ParkingInfoType.valueOf(parkingManagementReqDto.getParkingInfoType()),parkingManagementReqDto.getTitle(),parkingManagementReqDto.getDescription(),parkingManagementReqDto.getButtonName(),parkingManagementReqDto.getButtonTargetUrl(),parkingManagementReqDto.getBackgroundImage(), parkingManagementReqDto.isVisible());
+        parkingManagement.update(
+                parkingManagementReqDto.getHeaderName(),
+                ParkingInfoType.valueOf(parkingManagementReqDto.getParkingInfoType()),
+                parkingManagementReqDto.getTitle(),
+                parkingManagementReqDto.getDescription(),
+                parkingManagementReqDto.getButtonName(),
+                parkingManagementReqDto.getButtonTargetUrl(),
+                parkingManagementReqDto.getBackgroundImage(),
+                parkingManagementReqDto.isVisible());
     }
 
     @Transactional(readOnly = true)
-    public ParkingManagementSubPageResDto getParkingManagementSubPage(Long id){
-        ParkingManagement parkingManagement = parkingManagementRepository.findByIdWithImages(id)
+    public ParkingManagementSubPageResDto getParkingManagementSubPage(Long id) {
+        ParkingManagement parkingManagement = parkingManagementRepository
+                .findByIdWithImages(id)
                 .orElseThrow(() -> new ParkingManagementNotFoundException(id));
-        return new ParkingManagementSubPageResDto(parkingManagement.getSubPageHeaderName(),parkingManagement.getImages());
+        return new ParkingManagementSubPageResDto(
+                parkingManagement.getSubPageHeaderName(), parkingManagement.getImages());
     }
 
     @Transactional
-    public void updateSubPageHeaderName(Long id, ParkingSubPageReqDto parkingSubPageReqDto){
+    public void updateSubPageHeaderName(Long id, ParkingSubPageReqDto parkingSubPageReqDto) {
         ParkingManagement parkingManagement = loadParkingManagementOrThrow(id);
         parkingManagement.updateSubPageHeaderName(parkingSubPageReqDto.getSubPageHeaderName());
     }
 
     @Transactional
-    public void createParkingMapImage(Long id, FileDto fileDto){
+    public void createParkingMapImage(Long id, FileDto fileDto) {
         ParkingManagement parkingManagement = loadParkingManagementOrThrow(id);
         parkingManagement.addImage(fileDto.getUrl());
     }
 
     @Transactional
-    public void updateParkingMapImageDisplayOrder(Long id, ParkingMapImageReqDto parkingMapImageReqDto){
-        ParkingManagement parkingManagement = parkingManagementRepository.findByIdWithImages(id)
+    public void updateParkingMapImageDisplayOrder(Long id, ParkingMapImageReqDto parkingMapImageReqDto) {
+        ParkingManagement parkingManagement = parkingManagementRepository
+                .findByIdWithImages(id)
                 .orElseThrow(() -> new ParkingManagementNotFoundException(id));
 
         parkingManagement.reorderImages(parkingMapImageReqDto.getImageIds());
     }
 
     @Transactional
-    public void deleteParkingMapImages(Long id, ParkingMapImageReqDto parkingMapImageReqDto){
-        ParkingManagement parkingManagement = parkingManagementRepository.findByIdWithImages(id)
+    public void deleteParkingMapImages(Long id, ParkingMapImageReqDto parkingMapImageReqDto) {
+        ParkingManagement parkingManagement = parkingManagementRepository
+                .findByIdWithImages(id)
                 .orElseThrow(() -> new ParkingManagementNotFoundException(id));
         parkingManagement.removeImages(parkingMapImageReqDto.getImageIds());
     }

--- a/src/main/java/com/halo/eventer/global/constants/DisplayOrderConstants.java
+++ b/src/main/java/com/halo/eventer/global/constants/DisplayOrderConstants.java
@@ -2,4 +2,5 @@ package com.halo.eventer.global.constants;
 
 public class DisplayOrderConstants {
     public static final int DISPLAY_ORDER_DEFAULT = 11;
+    public static final int DISPLAY_ORDER_LIMIT_VALUE = 20;
 }

--- a/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
+++ b/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
@@ -54,8 +54,8 @@ public class SecurityConstants {
         "/maps/*/menus",
         "/test/festival",
         "/upload/preSigned",
-            "/api/v2/admin/parking-managements/*/sub-page-info",
-            "/api/v2/common/parking-managements/*",
+        "/api/v2/admin/parking-managements/*/sub-page-info",
+        "/api/v2/common/parking-managements/*",
     };
 
     public static final String[] PUBLIC_POST_URLS = {

--- a/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
+++ b/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
@@ -54,6 +54,8 @@ public class SecurityConstants {
         "/maps/*/menus",
         "/test/festival",
         "/upload/preSigned",
+            "/api/v2/admin/parking-managements/*/sub-page-info",
+            "/api/v2/common/parking-managements/*",
     };
 
     public static final String[] PUBLIC_POST_URLS = {

--- a/src/main/java/com/halo/eventer/global/error/ErrorCode.java
+++ b/src/main/java/com/halo/eventer/global/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     FORBIDDEN("C012", "Forbidden", 400),
     ERR_DATA_INTEGRITY_VIOLATION("E001", "Data integrity violation", 409),
     VALIDATION_FAILED("C013", "Validation Failed", 400),
+    MAX_COUNT_EXCEEDED("C014", "Exceeded maximum count (limit: 20)", 400),
 
     // Festival
     SUB_ADDRESS_ALREADY_EXISTS("F001", "subAddress Already Exists", 400),

--- a/src/main/java/com/halo/eventer/global/util/DisplayOrderUtils.java
+++ b/src/main/java/com/halo/eventer/global/util/DisplayOrderUtils.java
@@ -12,11 +12,11 @@ import lombok.NoArgsConstructor;
 public class DisplayOrderUtils {
 
     public static <T extends DisplayOrderUpdatable, R extends OrderUpdateRequest> void updateDisplayOrder(
-            List<T> widgets, List<R> orderRequests) {
+            List<T> targets, List<R> orderRequests) {
         Map<Long, Integer> orderMap = orderRequests.stream().collect(Collectors.toMap(R::getId, R::getDisplayOrder));
 
-        widgets.stream()
-                .filter(w -> orderMap.containsKey(w.getId()))
-                .forEach(w -> w.updateDisplayOrder(orderMap.get(w.getId())));
+        targets.stream()
+                .filter(t -> orderMap.containsKey(t.getId()))
+                .forEach(t -> t.updateDisplayOrder(orderMap.get(t.getId())));
     }
 }

--- a/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingManagementDoc.java
+++ b/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingManagementDoc.java
@@ -1,18 +1,18 @@
 package com.halo.eventer.domain.parking.api_docs;
 
-import com.halo.eventer.global.constants.ApiConstraint;
+import java.util.List;
+
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-
-import java.util.List;
+import com.halo.eventer.global.constants.ApiConstraint;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.snippet.Attributes.key;
 
@@ -28,8 +28,12 @@ public class ParkingManagementDoc {
                         .summary("에러 응답 형식")
                         .responseFields(
                                 fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
-                                fieldWithPath("message").type(JsonFieldType.STRING).description("상세 메시지"),
-                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"))
+                                fieldWithPath("message")
+                                        .type(JsonFieldType.STRING)
+                                        .description("상세 메시지"),
+                                fieldWithPath("status")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("HTTP 상태 코드"))
                         .build()));
     }
 
@@ -42,31 +46,44 @@ public class ParkingManagementDoc {
                         .summary("주차 관리 생성 (ADMIN)")
                         .description("축제 ID에 해당하는 주차 관리 영역을 생성합니다.")
                         .requestSchema(Schema.schema("ParkingManagementReqDto"))
-                        .pathParameters(
-                                parameterWithName("festivalId").description("축제 ID")
-                                        .attributes(key("constraints").value("필수, 1 이상의 양의 정수")))
-                        .requestHeaders(
-                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .pathParameters(parameterWithName("festivalId")
+                                .description("축제 ID")
+                                .attributes(key("constraints").value("필수, 1 이상의 양의 정수")))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
                         .requestFields(
-                                fieldWithPath("headerName").type(JsonFieldType.STRING)
+                                fieldWithPath("headerName")
+                                        .type(JsonFieldType.STRING)
                                         .description("헤더명")
                                         .attributes(key("constraints").value("필수, NotBlank")),
-                                fieldWithPath("parkingInfoType").type(JsonFieldType.STRING)
+                                fieldWithPath("parkingInfoType")
+                                        .type(JsonFieldType.STRING)
                                         .description("표시 타입 (BASIC|BUTTON|SIMPLE)")
                                         .attributes(key("constraints").value("필수, 패턴: BASIC|BUTTON|SIMPLE 중 선택")),
-                                fieldWithPath("title").type(JsonFieldType.STRING)
-                                        .description("타이틀").optional(),
-                                fieldWithPath("description").type(JsonFieldType.STRING)
-                                        .description("설명").optional(),
-                                fieldWithPath("buttonName").type(JsonFieldType.STRING)
-                                        .description("버튼명").optional(),
-                                fieldWithPath("buttonTargetUrl").type(JsonFieldType.STRING)
-                                        .description("버튼 링크 URL").optional()
+                                fieldWithPath("title")
+                                        .type(JsonFieldType.STRING)
+                                        .description("타이틀")
+                                        .optional(),
+                                fieldWithPath("description")
+                                        .type(JsonFieldType.STRING)
+                                        .description("설명")
+                                        .optional(),
+                                fieldWithPath("buttonName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("버튼명")
+                                        .optional(),
+                                fieldWithPath("buttonTargetUrl")
+                                        .type(JsonFieldType.STRING)
+                                        .description("버튼 링크 URL")
+                                        .optional()
                                         .attributes(key("constraints").value("URL 형식 권장")),
-                                fieldWithPath("backgroundImage").type(JsonFieldType.STRING)
-                                        .description("배경 이미지 URL").optional(),
-                                fieldWithPath("visible").type(JsonFieldType.BOOLEAN)
-                                        .description("노출 여부").optional())
+                                fieldWithPath("backgroundImage")
+                                        .type(JsonFieldType.STRING)
+                                        .description("배경 이미지 URL")
+                                        .optional(),
+                                fieldWithPath("visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부")
+                                        .optional())
                         .build()));
     }
 
@@ -78,27 +95,40 @@ public class ParkingManagementDoc {
                         .summary("주차 관리 수정 (ADMIN)")
                         .description("주차 관리 정보를 수정합니다.")
                         .requestSchema(Schema.schema("ParkingManagementReqDto"))
-                        .pathParameters(
-                                parameterWithName("id").description("주차 관리 ID")
-                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
-                        .requestHeaders(
-                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
                         .requestFields(
-                                fieldWithPath("headerName").type(JsonFieldType.STRING)
-                                        .description("헤더명").optional(),
-                                fieldWithPath("parkingInfoType").type(JsonFieldType.STRING)
+                                fieldWithPath("headerName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("헤더명")
+                                        .optional(),
+                                fieldWithPath("parkingInfoType")
+                                        .type(JsonFieldType.STRING)
                                         .description("표시 타입 (BASIC|BUTTON|SIMPLE)"),
-                                fieldWithPath("title").type(JsonFieldType.STRING)
-                                        .description("타이틀").optional(),
-                                fieldWithPath("description").type(JsonFieldType.STRING)
-                                        .description("설명").optional(),
-                                fieldWithPath("buttonName").type(JsonFieldType.STRING)
-                                        .description("버튼명").optional(),
-                                fieldWithPath("buttonTargetUrl").type(JsonFieldType.STRING)
-                                        .description("버튼 링크 URL").optional(),
-                                fieldWithPath("backgroundImage").type(JsonFieldType.STRING)
-                                        .description("배경 이미지 URL").optional(),
-                                fieldWithPath("visible").type(JsonFieldType.BOOLEAN)
+                                fieldWithPath("title")
+                                        .type(JsonFieldType.STRING)
+                                        .description("타이틀")
+                                        .optional(),
+                                fieldWithPath("description")
+                                        .type(JsonFieldType.STRING)
+                                        .description("설명")
+                                        .optional(),
+                                fieldWithPath("buttonName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("버튼명")
+                                        .optional(),
+                                fieldWithPath("buttonTargetUrl")
+                                        .type(JsonFieldType.STRING)
+                                        .description("버튼 링크 URL")
+                                        .optional(),
+                                fieldWithPath("backgroundImage")
+                                        .type(JsonFieldType.STRING)
+                                        .description("배경 이미지 URL")
+                                        .optional(),
+                                fieldWithPath("visible")
+                                        .type(JsonFieldType.BOOLEAN)
                                         .description("노출 여부"))
                         .build()));
     }
@@ -111,15 +141,14 @@ public class ParkingManagementDoc {
                         .summary("서브페이지 헤더명 수정 (ADMIN)")
                         .description("서브페이지 상단에 표시할 헤더명을 수정합니다.")
                         .requestSchema(Schema.schema("ParkingSubPageReqDto"))
-                        .pathParameters(
-                                parameterWithName("id").description("주차 관리 ID")
-                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
-                        .requestHeaders(
-                                headerWithName("Authorization").description("Bearer {JWT}"))
-                        .requestFields(
-                                fieldWithPath("subPageHeaderName").type(JsonFieldType.STRING)
-                                        .description("서브페이지 헤더명")
-                                        .attributes(key("constraints").value("필수, NotNull")))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(fieldWithPath("subPageHeaderName")
+                                .type(JsonFieldType.STRING)
+                                .description("서브페이지 헤더명")
+                                .attributes(key("constraints").value("필수, NotNull")))
                         .build()));
     }
 
@@ -131,17 +160,20 @@ public class ParkingManagementDoc {
                         .summary("주차맵 이미지 등록 (ADMIN)")
                         .description("주차 맵 이미지를 1건 등록합니다.")
                         .requestSchema(Schema.schema("FileDto"))
-                        .pathParameters(
-                                parameterWithName("id").description("주차 관리 ID")
-                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
-                        .requestHeaders(
-                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
                         .requestFields(
                                 // 프로젝트에 따라 필드명이 image 또는 url일 수 있어, 실제 DTO에 맞춰 한쪽을 사용하세요.
-                                fieldWithPath("image").type(JsonFieldType.STRING)
-                                        .description("이미지 URL/식별자").optional(),
-                                fieldWithPath("url").type(JsonFieldType.STRING)
-                                        .description("이미지 URL (대체 필드)").optional())
+                                fieldWithPath("image")
+                                        .type(JsonFieldType.STRING)
+                                        .description("이미지 URL/식별자")
+                                        .optional(),
+                                fieldWithPath("url")
+                                        .type(JsonFieldType.STRING)
+                                        .description("이미지 URL (대체 필드)")
+                                        .optional())
                         .build()));
     }
 
@@ -153,13 +185,13 @@ public class ParkingManagementDoc {
                         .summary("주차맵 이미지 정렬 변경 (ADMIN)")
                         .description("전달된 순서대로 이미지 표시 순서를 재배치합니다.")
                         .requestSchema(Schema.schema("ParkingMapImageReqDto"))
-                        .pathParameters(
-                                parameterWithName("id").description("주차 관리 ID")
-                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
-                        .requestHeaders(
-                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
                         .requestFields(
-                                fieldWithPath("imageIds").type(JsonFieldType.ARRAY)
+                                fieldWithPath("imageIds")
+                                        .type(JsonFieldType.ARRAY)
                                         .description("표시 순서대로 정렬할 이미지 ID 목록")
                                         .attributes(key("constraints").value("필수, 각 원소는 1 이상의 양의 정수")),
                                 fieldWithPath("imageIds[].").ignored())
@@ -174,15 +206,14 @@ public class ParkingManagementDoc {
                         .summary("주차맵 이미지 삭제 (ADMIN)")
                         .description("전달된 이미지 ID 목록을 삭제합니다.")
                         .requestSchema(Schema.schema("ParkingMapImageReqDto"))
-                        .pathParameters(
-                                parameterWithName("id").description("주차 관리 ID")
-                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
-                        .requestHeaders(
-                                headerWithName("Authorization").description("Bearer {JWT}"))
-                        .requestFields(
-                                fieldWithPath("imageIds").type(JsonFieldType.ARRAY)
-                                        .description("삭제할 이미지 ID 목록")
-                                        .attributes(key("constraints").value("필수, 각 원소는 1 이상의 양의 정수")))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(fieldWithPath("imageIds")
+                                .type(JsonFieldType.ARRAY)
+                                .description("삭제할 이미지 ID 목록")
+                                .attributes(key("constraints").value("필수, 각 원소는 1 이상의 양의 정수")))
                         .build()));
     }
 
@@ -195,18 +226,39 @@ public class ParkingManagementDoc {
                         .summary("주차 관리 단건 조회 (COMMON)")
                         .description("주차 관리 영역(공통)을 조회합니다.")
                         .responseSchema(Schema.schema("ParkingManagementResDto"))
-                        .pathParameters(
-                                parameterWithName("id").description("주차 관리 ID")
-                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
                         .responseFields(
-                                fieldWithPath("headerName").type(JsonFieldType.STRING).description("헤더명"),
-                                fieldWithPath("parkingInfoType").type(JsonFieldType.STRING).description("표시 타입"),
-                                fieldWithPath("title").type(JsonFieldType.STRING).description("타이틀").optional(),
-                                fieldWithPath("description").type(JsonFieldType.STRING).description("설명").optional(),
-                                fieldWithPath("buttonName").type(JsonFieldType.STRING).description("버튼명").optional(),
-                                fieldWithPath("buttonTargetUrl").type(JsonFieldType.STRING).description("버튼 링크 URL").optional(),
-                                fieldWithPath("backgroundImage").type(JsonFieldType.STRING).description("배경 이미지 URL").optional(),
-                                fieldWithPath("visible").type(JsonFieldType.BOOLEAN).description("노출 여부"))
+                                fieldWithPath("headerName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("헤더명"),
+                                fieldWithPath("parkingInfoType")
+                                        .type(JsonFieldType.STRING)
+                                        .description("표시 타입"),
+                                fieldWithPath("title")
+                                        .type(JsonFieldType.STRING)
+                                        .description("타이틀")
+                                        .optional(),
+                                fieldWithPath("description")
+                                        .type(JsonFieldType.STRING)
+                                        .description("설명")
+                                        .optional(),
+                                fieldWithPath("buttonName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("버튼명")
+                                        .optional(),
+                                fieldWithPath("buttonTargetUrl")
+                                        .type(JsonFieldType.STRING)
+                                        .description("버튼 링크 URL")
+                                        .optional(),
+                                fieldWithPath("backgroundImage")
+                                        .type(JsonFieldType.STRING)
+                                        .description("배경 이미지 URL")
+                                        .optional(),
+                                fieldWithPath("visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부"))
                         .build()));
     }
 
@@ -218,16 +270,23 @@ public class ParkingManagementDoc {
                         .summary("서브페이지 정보 조회 (ADMIN)")
                         .description("서브페이지 헤더명과 주차 맵 이미지 목록을 조회합니다.")
                         .responseSchema(Schema.schema("ParkingManagementSubPageResDto"))
-                        .pathParameters(
-                                parameterWithName("id").description("주차 관리 ID")
-                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
-                        .requestHeaders(
-                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
                         .responseFields(
-                                fieldWithPath("subPageHeaderName").type(JsonFieldType.STRING).description("서브페이지 헤더명"),
-                                fieldWithPath("images").type(JsonFieldType.ARRAY).description("이미지 목록"),
-                                fieldWithPath("images[].id").type(JsonFieldType.NUMBER).description("이미지 ID"),
-                                fieldWithPath("images[].image").type(JsonFieldType.STRING).description("이미지 URL/식별자"))
+                                fieldWithPath("subPageHeaderName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("서브페이지 헤더명"),
+                                fieldWithPath("images")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("이미지 목록"),
+                                fieldWithPath("images[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("이미지 ID"),
+                                fieldWithPath("images[].image")
+                                        .type(JsonFieldType.STRING)
+                                        .description("이미지 URL/식별자"))
                         .build()));
     }
 }

--- a/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingManagementDoc.java
+++ b/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingManagementDoc.java
@@ -1,0 +1,233 @@
+package com.halo.eventer.domain.parking.api_docs;
+
+import com.halo.eventer.global.constants.ApiConstraint;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+public class ParkingManagementDoc {
+
+    private static final String TAG = "주차 관리";
+
+    public static RestDocumentationResultHandler errorSnippet(String identifier) {
+        return document(
+                identifier,
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("에러 응답 형식")
+                        .responseFields(
+                                fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("상세 메시지"),
+                                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"))
+                        .build()));
+    }
+
+    // ========== ADMIN ==========
+    public static RestDocumentationResultHandler create() {
+        return document(
+                "parking-management 생성",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차 관리 생성 (ADMIN)")
+                        .description("축제 ID에 해당하는 주차 관리 영역을 생성합니다.")
+                        .requestSchema(Schema.schema("ParkingManagementReqDto"))
+                        .pathParameters(
+                                parameterWithName("festivalId").description("축제 ID")
+                                        .attributes(key("constraints").value("필수, 1 이상의 양의 정수")))
+                        .requestHeaders(
+                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                fieldWithPath("headerName").type(JsonFieldType.STRING)
+                                        .description("헤더명")
+                                        .attributes(key("constraints").value("필수, NotBlank")),
+                                fieldWithPath("parkingInfoType").type(JsonFieldType.STRING)
+                                        .description("표시 타입 (BASIC|BUTTON|SIMPLE)")
+                                        .attributes(key("constraints").value("필수, 패턴: BASIC|BUTTON|SIMPLE 중 선택")),
+                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                        .description("타이틀").optional(),
+                                fieldWithPath("description").type(JsonFieldType.STRING)
+                                        .description("설명").optional(),
+                                fieldWithPath("buttonName").type(JsonFieldType.STRING)
+                                        .description("버튼명").optional(),
+                                fieldWithPath("buttonTargetUrl").type(JsonFieldType.STRING)
+                                        .description("버튼 링크 URL").optional()
+                                        .attributes(key("constraints").value("URL 형식 권장")),
+                                fieldWithPath("backgroundImage").type(JsonFieldType.STRING)
+                                        .description("배경 이미지 URL").optional(),
+                                fieldWithPath("visible").type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부").optional())
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler update() {
+        return document(
+                "parking-management 수정",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차 관리 수정 (ADMIN)")
+                        .description("주차 관리 정보를 수정합니다.")
+                        .requestSchema(Schema.schema("ParkingManagementReqDto"))
+                        .pathParameters(
+                                parameterWithName("id").description("주차 관리 ID")
+                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(
+                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                fieldWithPath("headerName").type(JsonFieldType.STRING)
+                                        .description("헤더명").optional(),
+                                fieldWithPath("parkingInfoType").type(JsonFieldType.STRING)
+                                        .description("표시 타입 (BASIC|BUTTON|SIMPLE)"),
+                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                        .description("타이틀").optional(),
+                                fieldWithPath("description").type(JsonFieldType.STRING)
+                                        .description("설명").optional(),
+                                fieldWithPath("buttonName").type(JsonFieldType.STRING)
+                                        .description("버튼명").optional(),
+                                fieldWithPath("buttonTargetUrl").type(JsonFieldType.STRING)
+                                        .description("버튼 링크 URL").optional(),
+                                fieldWithPath("backgroundImage").type(JsonFieldType.STRING)
+                                        .description("배경 이미지 URL").optional(),
+                                fieldWithPath("visible").type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler updateSubPageHeaderName() {
+        return document(
+                "parking-management 서브페이지-헤더명 수정",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("서브페이지 헤더명 수정 (ADMIN)")
+                        .description("서브페이지 상단에 표시할 헤더명을 수정합니다.")
+                        .requestSchema(Schema.schema("ParkingSubPageReqDto"))
+                        .pathParameters(
+                                parameterWithName("id").description("주차 관리 ID")
+                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(
+                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                fieldWithPath("subPageHeaderName").type(JsonFieldType.STRING)
+                                        .description("서브페이지 헤더명")
+                                        .attributes(key("constraints").value("필수, NotNull")))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler createParkingMapImage() {
+        return document(
+                "parking-management 주차맵이미지 등록",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차맵 이미지 등록 (ADMIN)")
+                        .description("주차 맵 이미지를 1건 등록합니다.")
+                        .requestSchema(Schema.schema("FileDto"))
+                        .pathParameters(
+                                parameterWithName("id").description("주차 관리 ID")
+                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(
+                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                // 프로젝트에 따라 필드명이 image 또는 url일 수 있어, 실제 DTO에 맞춰 한쪽을 사용하세요.
+                                fieldWithPath("image").type(JsonFieldType.STRING)
+                                        .description("이미지 URL/식별자").optional(),
+                                fieldWithPath("url").type(JsonFieldType.STRING)
+                                        .description("이미지 URL (대체 필드)").optional())
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler updateParkingMapImageDisplayOrder() {
+        return document(
+                "parking-management 주차맵이미지 정렬변경",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차맵 이미지 정렬 변경 (ADMIN)")
+                        .description("전달된 순서대로 이미지 표시 순서를 재배치합니다.")
+                        .requestSchema(Schema.schema("ParkingMapImageReqDto"))
+                        .pathParameters(
+                                parameterWithName("id").description("주차 관리 ID")
+                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(
+                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                fieldWithPath("imageIds").type(JsonFieldType.ARRAY)
+                                        .description("표시 순서대로 정렬할 이미지 ID 목록")
+                                        .attributes(key("constraints").value("필수, 각 원소는 1 이상의 양의 정수")),
+                                fieldWithPath("imageIds[].").ignored())
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler deleteParkingMapImages() {
+        return document(
+                "parking-management 주차맵이미지 삭제",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차맵 이미지 삭제 (ADMIN)")
+                        .description("전달된 이미지 ID 목록을 삭제합니다.")
+                        .requestSchema(Schema.schema("ParkingMapImageReqDto"))
+                        .pathParameters(
+                                parameterWithName("id").description("주차 관리 ID")
+                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(
+                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                fieldWithPath("imageIds").type(JsonFieldType.ARRAY)
+                                        .description("삭제할 이미지 ID 목록")
+                                        .attributes(key("constraints").value("필수, 각 원소는 1 이상의 양의 정수")))
+                        .build()));
+    }
+
+    // ========== 조회 ==========
+    public static RestDocumentationResultHandler getOne() {
+        return document(
+                "parking-management 단건조회",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차 관리 단건 조회 (COMMON)")
+                        .description("주차 관리 영역(공통)을 조회합니다.")
+                        .responseSchema(Schema.schema("ParkingManagementResDto"))
+                        .pathParameters(
+                                parameterWithName("id").description("주차 관리 ID")
+                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .responseFields(
+                                fieldWithPath("headerName").type(JsonFieldType.STRING).description("헤더명"),
+                                fieldWithPath("parkingInfoType").type(JsonFieldType.STRING).description("표시 타입"),
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("타이틀").optional(),
+                                fieldWithPath("description").type(JsonFieldType.STRING).description("설명").optional(),
+                                fieldWithPath("buttonName").type(JsonFieldType.STRING).description("버튼명").optional(),
+                                fieldWithPath("buttonTargetUrl").type(JsonFieldType.STRING).description("버튼 링크 URL").optional(),
+                                fieldWithPath("backgroundImage").type(JsonFieldType.STRING).description("배경 이미지 URL").optional(),
+                                fieldWithPath("visible").type(JsonFieldType.BOOLEAN).description("노출 여부"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler getSubPageInfo() {
+        return document(
+                "parking-management 서브페이지 조회",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("서브페이지 정보 조회 (ADMIN)")
+                        .description("서브페이지 헤더명과 주차 맵 이미지 목록을 조회합니다.")
+                        .responseSchema(Schema.schema("ParkingManagementSubPageResDto"))
+                        .pathParameters(
+                                parameterWithName("id").description("주차 관리 ID")
+                                        .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(
+                                headerWithName("Authorization").description("Bearer {JWT}"))
+                        .responseFields(
+                                fieldWithPath("subPageHeaderName").type(JsonFieldType.STRING).description("서브페이지 헤더명"),
+                                fieldWithPath("images").type(JsonFieldType.ARRAY).description("이미지 목록"),
+                                fieldWithPath("images[].id").type(JsonFieldType.NUMBER).description("이미지 ID"),
+                                fieldWithPath("images[].image").type(JsonFieldType.STRING).description("이미지 URL/식별자"))
+                        .build()));
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/controller/ParkingManagementControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/controller/ParkingManagementControllerTest.java
@@ -1,0 +1,385 @@
+package com.halo.eventer.domain.parking.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.image.dto.FileDto;
+import com.halo.eventer.domain.image.dto.ImageDto;
+import com.halo.eventer.domain.parking.api_docs.ParkingManagementDoc;
+import com.halo.eventer.domain.parking.dto.ParkingManagementReqDto;
+import com.halo.eventer.domain.parking.dto.ParkingManagementResDto;
+import com.halo.eventer.domain.parking.dto.ParkingManagementSubPageResDto;
+import com.halo.eventer.domain.parking.dto.ParkingMapImageReqDto;
+import com.halo.eventer.domain.parking.dto.ParkingSubPageReqDto;
+import com.halo.eventer.domain.parking.service.ParkingManagementService;
+import com.halo.eventer.global.config.ControllerTestSecurityBeans;
+import com.halo.eventer.global.config.security.SecurityConfig;
+import com.halo.eventer.global.security.provider.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.halo.eventer.global.common.ApiErrorAssert.assertError;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ParkingManagementController.class)
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
+class ParkingManagementControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean ParkingManagementService parkingManagementService;
+    @MockitoBean JwtProvider jwtProvider;
+
+    private static final String ADMIN_TOKEN = "Bearer admin-token";
+    private static final long VALID_ID = 1L;
+    private static final long INVALID_ID = 0L;
+
+    private Map<String, Object> validCreateBody;
+
+    @BeforeEach
+    void setUp() {
+        // DTO 실제 필드에 맞춘 요청 본문
+        validCreateBody = Map.of(
+                "headerName", "주차 안내",
+                "parkingInfoType", "BASIC", // Pattern: BASIC|BUTTON|SIMPLE
+                "title", "캠퍼스 주차 정보",
+                "description", "주차장 위치와 요금 안내",
+                "buttonName", "자세히 보기",
+                "buttonTargetUrl", "https://example.com/parking",
+                "backgroundImage", "https://cdn/bg.png",
+                "visible", true
+        );
+    }
+
+    // ======================= ADMIN =======================
+    @Nested
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    class 어드민_엔드포인트 {
+
+        @Test
+        void 생성_성공() throws Exception {
+            doNothing().when(parkingManagementService).create(eq(VALID_ID), any(ParkingManagementReqDto.class));
+
+            mockMvc.perform(post("/api/v2/admin/festivals/{festivalId}/parking-managements", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validCreateBody)))
+                    .andExpect(status().isOk())
+                    .andDo(ParkingManagementDoc.create());
+        }
+
+        @Test
+        void 생성_실패_festivalId_Min_검증() throws Exception {
+            ResultActions result = mockMvc.perform(post("/api/v2/admin/festivals/{festivalId}/parking-managements", INVALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validCreateBody)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차 관리 시스템 생성 festivalId 검증 실패"));
+            assertError(result, "C013", "must be greater than or equal to 1", 400);
+        }
+
+        @Test
+        void 생성_실패_parkingInfoType_Pattern_검증() throws Exception {
+            Map<String, Object> badRequest = Map.of(
+                    "headerName", "주차 안내",
+                    "parkingInfoType", "INVALID",
+                    "title", "캠퍼스 주차 정보",
+                    "description", "주차장 위치와 요금 안내",
+                    "buttonName", "자세히 보기",
+                    "buttonTargetUrl", "https://example.com/parking",
+                    "backgroundImage", "https://cdn/bg.png",
+                    "visible", true
+            );
+
+            ResultActions result = mockMvc.perform(post("/api/v2/admin/festivals/{festivalId}/parking-managements", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(badRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차 관리 시스템 생성시 parkingInfoType 패턴 오류"));
+            assertError(result, "C013", "parkingInfoType must be one of: BASIC, BUTTON, SIMPLE", 400);
+        }
+
+        @Test
+        void 수정_성공() throws Exception {
+            doNothing().when(parkingManagementService).update(eq(VALID_ID), any(ParkingManagementReqDto.class));
+
+            mockMvc.perform(put("/api/v2/admin/parking-managements/{id}", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validCreateBody)))
+                    .andExpect(status().isOk())
+                    .andDo(ParkingManagementDoc.update());
+        }
+
+        @Test
+        void 수정_실패_id_Min_검증() throws Exception {
+            ResultActions result = mockMvc.perform(put("/api/v2/admin/parking-managements/{id}", INVALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validCreateBody)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차 관리 시스템 수정시 id 값 오류"));
+            assertError(result, "C013", "must be greater than or equal to 1", 400);
+        }
+
+        @Test
+        void 서브페이지_헤더명_수정_성공() throws Exception {
+            doNothing().when(parkingManagementService).updateSubPageHeaderName(eq(VALID_ID), any(ParkingSubPageReqDto.class));
+
+            Map<String, Object> body = Map.of("subPageHeaderName", "주차구역 안내");
+            mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isOk())
+                    .andDo(ParkingManagementDoc.updateSubPageHeaderName());
+        }
+
+        @Test
+        void 서브페이지_헤더명_수정_실패_id_Min_검증() throws Exception {
+            ParkingSubPageReqDto body = new ParkingSubPageReqDto("주차 구역안내");
+            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", INVALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("서브페이지 헤더명 수정시 id 오류"));
+            assertError(result, "C013", "must be greater than or equal to 1", 400);
+        }
+
+        @Test
+        void 서브페이지_헤더명_수정_실패_필드_NotNull() throws Exception {
+            ParkingSubPageReqDto body = new ParkingSubPageReqDto();
+
+            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("서브페이지 헤더명 Null일 경우"));
+            assertError(result, "C013", "must not be null", 400);
+        }
+
+        @Test
+        void 주차맵이미지_등록_성공() throws Exception {
+            doNothing().when(parkingManagementService).createParkingMapImage(eq(VALID_ID), any(FileDto.class));
+            FileDto fileDto = new FileDto("url");
+
+            mockMvc.perform(post("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(fileDto)))
+                    .andExpect(status().isOk())
+                    .andDo(ParkingManagementDoc.createParkingMapImage());
+        }
+
+        @Test
+        void 주차맵이미지_등록_실패_id_Min_검증() throws Exception {
+            FileDto fileDto = new FileDto("url");
+
+            ResultActions result = mockMvc.perform(post("/api/v2/admin/parking-managements/{id}/parking-map-images", INVALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(fileDto)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지_등록시_id_오류"));
+            assertError(result, "C013", "must be greater than or equal to 1", 400);
+        }
+
+        @Test
+        void 주차맵이미지_정렬변경_성공() throws Exception {
+            doNothing().when(parkingManagementService).updateParkingMapImageDisplayOrder(eq(VALID_ID), any(ParkingMapImageReqDto.class));
+
+            Map<String, Object> body = Map.of("imageIds", List.of(3L, 1L, 2L));
+            mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isOk())
+                    .andDo(ParkingManagementDoc.updateParkingMapImageDisplayOrder());
+        }
+
+        @Test
+        void 주차맵이미지_정렬변경_실패_id_Min_검증() throws Exception {
+            Map<String, Object> body = Map.of("imageIds", List.of(3L, 1L, 0L));
+            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", INVALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 순서변경시 id 오류"));
+            assertError(result, "C013", "must be greater than or equal to 1", 400);
+        }
+
+        @Test
+        void 주차맵이미지_삭제_성공() throws Exception {
+            doNothing().when(parkingManagementService).deleteParkingMapImages(eq(VALID_ID), any(ParkingMapImageReqDto.class));
+
+            Map<String, Object> body = Map.of("imageIds", List.of(10L, 11L));
+            mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isOk())
+                    .andDo(ParkingManagementDoc.deleteParkingMapImages());
+        }
+
+        @Test
+        void 주차맵이미지_삭제_실패_id_Min_검증() throws Exception {
+            Map<String, Object> body = Map.of("imageIds", List.of(0L, 11L));
+            ResultActions result = mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", INVALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 삭제시 id 오류"));
+            assertError(result, "C013", "must be greater than or equal to 1", 400);
+        }
+
+        @Test
+        void 주차맵이미지_삭제_실패_imageIds_NotNull() throws Exception {
+            Map<String, Object> body = Map.of();
+            ResultActions result = mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 삭제시 id가 NULL"));
+            assertError(result, "C013", "must not be null", 400);
+        }
+    }
+
+    @Nested
+    class 인증_실패 {
+
+        @Test
+        void 생성_권한없음() throws Exception {
+            ResultActions result = mockMvc.perform(post("/api/v2/admin/festivals/{festivalId}/parking-managements", VALID_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validCreateBody)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차관리 생성시 인증 거부"));
+            assertError(result, "A002", "Unauthenticated", 401);
+        }
+
+        @Test
+        void 수정_권한없음() throws Exception {
+            ResultActions result = mockMvc.perform(put("/api/v2/admin/parking-managements/{id}", VALID_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validCreateBody)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차관리 수정시 인증 거부"));
+            assertError(result, "A002", "Unauthenticated", 401);
+        }
+
+        @Test
+        void 서브페이지_헤더명_수정_권한없음() throws Exception {
+            Map<String, Object> body = Map.of("subPageHeaderName", "주차구역 안내");
+            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(ParkingManagementDoc.errorSnippet("서브페이지 수정시 인증 거부"));
+            assertError(result, "A002", "Unauthenticated", 401);
+        }
+
+        @Test
+        void 정렬변경_권한없음() throws Exception {
+            Map<String, Object> body = Map.of("imageIds", List.of(1L, 2L));
+            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", VALID_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 순서변경 인증 거부"));
+            assertError(result, "A002", "Unauthenticated", 401);
+        }
+
+        @Test
+        void 이미지삭제_권한없음() throws Exception {
+            Map<String, Object> body = Map.of("imageIds", List.of(1L, 2L));
+            ResultActions result = mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 삭제시 인증 거부"));
+            assertError(result, "A002", "Unauthenticated", 401);
+        }
+    }
+
+    @Nested
+    class 조회_엔드포인트 {
+
+        @Test
+        void 단건조회_COMMON_성공() throws Exception {
+            ParkingManagementResDto res = new ParkingManagementResDto();
+            ReflectionTestUtils.setField(res, "headerName", "주차 안내");
+            ReflectionTestUtils.setField(res, "parkingInfoType", "BASIC");
+            ReflectionTestUtils.setField(res, "title", "캠퍼스 주차 정보");
+            ReflectionTestUtils.setField(res, "description", "요약");
+            ReflectionTestUtils.setField(res, "buttonName", "자세히");
+            ReflectionTestUtils.setField(res, "buttonTargetUrl", "https://example.com");
+            ReflectionTestUtils.setField(res, "backgroundImage", "https://cdn/bg.png");
+            ReflectionTestUtils.setField(res, "visible", true);
+
+            given(parkingManagementService.getParkingManagement(VALID_ID)).willReturn(res);
+
+            mockMvc.perform(get("/api/v2/common/parking-managements/{id}", VALID_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.headerName").value("주차 안내"))
+                    .andExpect(jsonPath("$.parkingInfoType").value("BASIC"))
+                    .andExpect(jsonPath("$.title").value("캠퍼스 주차 정보"))
+                    .andExpect(jsonPath("$.visible").value(true))
+                    .andExpect(jsonPath("$.description").value(res.getDescription()))
+                    .andExpect(jsonPath("$.buttonName").value(res.getButtonName()))
+                    .andExpect(jsonPath("$.buttonTargetUrl").value(res.getButtonTargetUrl()))
+                    .andExpect(jsonPath("$.backgroundImage").value(res.getBackgroundImage()))
+                    .andDo(ParkingManagementDoc.getOne());
+        }
+
+        @Test
+
+        void 서브페이지조회_성공() throws Exception {
+            ParkingManagementSubPageResDto res = new ParkingManagementSubPageResDto();
+            ImageDto imageDto1 = new ImageDto();
+            ImageDto imageDto2 = new ImageDto();
+            ReflectionTestUtils.setField(imageDto1, "id",1L);
+            ReflectionTestUtils.setField(imageDto1, "image","image1");
+            ReflectionTestUtils.setField(imageDto2, "id",2L);
+            ReflectionTestUtils.setField(imageDto2, "image","image2");
+            ReflectionTestUtils.setField(res, "subPageHeaderName", "주차구역 안내");
+            ReflectionTestUtils.setField(res, "images", List.of(imageDto1, imageDto2));
+
+            given(parkingManagementService.getParkingManagementSubPage(VALID_ID)).willReturn(res);
+
+            mockMvc.perform(get("/api/v2/admin/parking-managements/{id}/sub-page-info", VALID_ID)
+                            .header("Authorization", ADMIN_TOKEN))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.subPageHeaderName").value("주차구역 안내"))
+                    .andExpect(jsonPath("$.images.length()").value(2))
+                    .andDo(ParkingManagementDoc.getSubPageInfo());
+        }
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/controller/ParkingManagementControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/controller/ParkingManagementControllerTest.java
@@ -1,18 +1,8 @@
 package com.halo.eventer.domain.parking.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.halo.eventer.domain.image.dto.FileDto;
-import com.halo.eventer.domain.image.dto.ImageDto;
-import com.halo.eventer.domain.parking.api_docs.ParkingManagementDoc;
-import com.halo.eventer.domain.parking.dto.ParkingManagementReqDto;
-import com.halo.eventer.domain.parking.dto.ParkingManagementResDto;
-import com.halo.eventer.domain.parking.dto.ParkingManagementSubPageResDto;
-import com.halo.eventer.domain.parking.dto.ParkingMapImageReqDto;
-import com.halo.eventer.domain.parking.dto.ParkingSubPageReqDto;
-import com.halo.eventer.domain.parking.service.ParkingManagementService;
-import com.halo.eventer.global.config.ControllerTestSecurityBeans;
-import com.halo.eventer.global.config.security.SecurityConfig;
-import com.halo.eventer.global.security.provider.JwtProvider;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,8 +18,19 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.image.dto.FileDto;
+import com.halo.eventer.domain.image.dto.ImageDto;
+import com.halo.eventer.domain.parking.api_docs.ParkingManagementDoc;
+import com.halo.eventer.domain.parking.dto.ParkingManagementReqDto;
+import com.halo.eventer.domain.parking.dto.ParkingManagementResDto;
+import com.halo.eventer.domain.parking.dto.ParkingManagementSubPageResDto;
+import com.halo.eventer.domain.parking.dto.ParkingMapImageReqDto;
+import com.halo.eventer.domain.parking.dto.ParkingSubPageReqDto;
+import com.halo.eventer.domain.parking.service.ParkingManagementService;
+import com.halo.eventer.global.config.ControllerTestSecurityBeans;
+import com.halo.eventer.global.config.security.SecurityConfig;
+import com.halo.eventer.global.security.provider.JwtProvider;
 
 import static com.halo.eventer.global.common.ApiErrorAssert.assertError;
 import static org.mockito.ArgumentMatchers.*;
@@ -45,11 +46,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
 class ParkingManagementControllerTest {
 
-    @Autowired MockMvc mockMvc;
-    @Autowired ObjectMapper objectMapper;
+    @Autowired
+    MockMvc mockMvc;
 
-    @MockitoBean ParkingManagementService parkingManagementService;
-    @MockitoBean JwtProvider jwtProvider;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    ParkingManagementService parkingManagementService;
+
+    @MockitoBean
+    JwtProvider jwtProvider;
 
     private static final String ADMIN_TOKEN = "Bearer admin-token";
     private static final long VALID_ID = 1L;
@@ -68,8 +75,7 @@ class ParkingManagementControllerTest {
                 "buttonName", "자세히 보기",
                 "buttonTargetUrl", "https://example.com/parking",
                 "backgroundImage", "https://cdn/bg.png",
-                "visible", true
-        );
+                "visible", true);
     }
 
     // ======================= ADMIN =======================
@@ -91,10 +97,11 @@ class ParkingManagementControllerTest {
 
         @Test
         void 생성_실패_festivalId_Min_검증() throws Exception {
-            ResultActions result = mockMvc.perform(post("/api/v2/admin/festivals/{festivalId}/parking-managements", INVALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(validCreateBody)))
+            ResultActions result = mockMvc.perform(
+                            post("/api/v2/admin/festivals/{festivalId}/parking-managements", INVALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(validCreateBody)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("주차 관리 시스템 생성 festivalId 검증 실패"));
             assertError(result, "C013", "must be greater than or equal to 1", 400);
@@ -110,13 +117,13 @@ class ParkingManagementControllerTest {
                     "buttonName", "자세히 보기",
                     "buttonTargetUrl", "https://example.com/parking",
                     "backgroundImage", "https://cdn/bg.png",
-                    "visible", true
-            );
+                    "visible", true);
 
-            ResultActions result = mockMvc.perform(post("/api/v2/admin/festivals/{festivalId}/parking-managements", VALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(badRequest)))
+            ResultActions result = mockMvc.perform(
+                            post("/api/v2/admin/festivals/{festivalId}/parking-managements", VALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(badRequest)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("주차 관리 시스템 생성시 parkingInfoType 패턴 오류"));
             assertError(result, "C013", "parkingInfoType must be one of: BASIC, BUTTON, SIMPLE", 400);
@@ -147,7 +154,9 @@ class ParkingManagementControllerTest {
 
         @Test
         void 서브페이지_헤더명_수정_성공() throws Exception {
-            doNothing().when(parkingManagementService).updateSubPageHeaderName(eq(VALID_ID), any(ParkingSubPageReqDto.class));
+            doNothing()
+                    .when(parkingManagementService)
+                    .updateSubPageHeaderName(eq(VALID_ID), any(ParkingSubPageReqDto.class));
 
             Map<String, Object> body = Map.of("subPageHeaderName", "주차구역 안내");
             mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
@@ -161,10 +170,11 @@ class ParkingManagementControllerTest {
         @Test
         void 서브페이지_헤더명_수정_실패_id_Min_검증() throws Exception {
             ParkingSubPageReqDto body = new ParkingSubPageReqDto("주차 구역안내");
-            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", INVALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", INVALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("서브페이지 헤더명 수정시 id 오류"));
             assertError(result, "C013", "must be greater than or equal to 1", 400);
@@ -174,10 +184,11 @@ class ParkingManagementControllerTest {
         void 서브페이지_헤더명_수정_실패_필드_NotNull() throws Exception {
             ParkingSubPageReqDto body = new ParkingSubPageReqDto();
 
-            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("서브페이지 헤더명 Null일 경우"));
             assertError(result, "C013", "must not be null", 400);
@@ -200,10 +211,11 @@ class ParkingManagementControllerTest {
         void 주차맵이미지_등록_실패_id_Min_검증() throws Exception {
             FileDto fileDto = new FileDto("url");
 
-            ResultActions result = mockMvc.perform(post("/api/v2/admin/parking-managements/{id}/parking-map-images", INVALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(fileDto)))
+            ResultActions result = mockMvc.perform(
+                            post("/api/v2/admin/parking-managements/{id}/parking-map-images", INVALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(fileDto)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지_등록시_id_오류"));
             assertError(result, "C013", "must be greater than or equal to 1", 400);
@@ -211,7 +223,9 @@ class ParkingManagementControllerTest {
 
         @Test
         void 주차맵이미지_정렬변경_성공() throws Exception {
-            doNothing().when(parkingManagementService).updateParkingMapImageDisplayOrder(eq(VALID_ID), any(ParkingMapImageReqDto.class));
+            doNothing()
+                    .when(parkingManagementService)
+                    .updateParkingMapImageDisplayOrder(eq(VALID_ID), any(ParkingMapImageReqDto.class));
 
             Map<String, Object> body = Map.of("imageIds", List.of(3L, 1L, 2L));
             mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", VALID_ID)
@@ -225,10 +239,11 @@ class ParkingManagementControllerTest {
         @Test
         void 주차맵이미지_정렬변경_실패_id_Min_검증() throws Exception {
             Map<String, Object> body = Map.of("imageIds", List.of(3L, 1L, 0L));
-            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", INVALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", INVALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 순서변경시 id 오류"));
             assertError(result, "C013", "must be greater than or equal to 1", 400);
@@ -236,7 +251,9 @@ class ParkingManagementControllerTest {
 
         @Test
         void 주차맵이미지_삭제_성공() throws Exception {
-            doNothing().when(parkingManagementService).deleteParkingMapImages(eq(VALID_ID), any(ParkingMapImageReqDto.class));
+            doNothing()
+                    .when(parkingManagementService)
+                    .deleteParkingMapImages(eq(VALID_ID), any(ParkingMapImageReqDto.class));
 
             Map<String, Object> body = Map.of("imageIds", List.of(10L, 11L));
             mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
@@ -250,10 +267,11 @@ class ParkingManagementControllerTest {
         @Test
         void 주차맵이미지_삭제_실패_id_Min_검증() throws Exception {
             Map<String, Object> body = Map.of("imageIds", List.of(0L, 11L));
-            ResultActions result = mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", INVALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            delete("/api/v2/admin/parking-managements/{id}/parking-map-images", INVALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 삭제시 id 오류"));
             assertError(result, "C013", "must be greater than or equal to 1", 400);
@@ -262,10 +280,11 @@ class ParkingManagementControllerTest {
         @Test
         void 주차맵이미지_삭제_실패_imageIds_NotNull() throws Exception {
             Map<String, Object> body = Map.of();
-            ResultActions result = mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
-                            .header("Authorization", ADMIN_TOKEN)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
+                                    .header("Authorization", ADMIN_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isBadRequest())
                     .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 삭제시 id가 NULL"));
             assertError(result, "C013", "must not be null", 400);
@@ -277,9 +296,10 @@ class ParkingManagementControllerTest {
 
         @Test
         void 생성_권한없음() throws Exception {
-            ResultActions result = mockMvc.perform(post("/api/v2/admin/festivals/{festivalId}/parking-managements", VALID_ID)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(validCreateBody)))
+            ResultActions result = mockMvc.perform(
+                            post("/api/v2/admin/festivals/{festivalId}/parking-managements", VALID_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(validCreateBody)))
                     .andExpect(status().isUnauthorized())
                     .andDo(ParkingManagementDoc.errorSnippet("주차관리 생성시 인증 거부"));
             assertError(result, "A002", "Unauthenticated", 401);
@@ -298,9 +318,10 @@ class ParkingManagementControllerTest {
         @Test
         void 서브페이지_헤더명_수정_권한없음() throws Exception {
             Map<String, Object> body = Map.of("subPageHeaderName", "주차구역 안내");
-            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            patch("/api/v2/admin/parking-managements/{id}/sub-page-header-name", VALID_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isUnauthorized())
                     .andDo(ParkingManagementDoc.errorSnippet("서브페이지 수정시 인증 거부"));
             assertError(result, "A002", "Unauthenticated", 401);
@@ -309,9 +330,10 @@ class ParkingManagementControllerTest {
         @Test
         void 정렬변경_권한없음() throws Exception {
             Map<String, Object> body = Map.of("imageIds", List.of(1L, 2L));
-            ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", VALID_ID)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            patch("/api/v2/admin/parking-managements/{id}/parking-map-images/display-order", VALID_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isUnauthorized())
                     .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 순서변경 인증 거부"));
             assertError(result, "A002", "Unauthenticated", 401);
@@ -320,9 +342,10 @@ class ParkingManagementControllerTest {
         @Test
         void 이미지삭제_권한없음() throws Exception {
             Map<String, Object> body = Map.of("imageIds", List.of(1L, 2L));
-            ResultActions result = mockMvc.perform(delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(body)))
+            ResultActions result = mockMvc.perform(
+                            delete("/api/v2/admin/parking-managements/{id}/parking-map-images", VALID_ID)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isUnauthorized())
                     .andDo(ParkingManagementDoc.errorSnippet("주차맵이미지 삭제시 인증 거부"));
             assertError(result, "A002", "Unauthenticated", 401);
@@ -360,19 +383,19 @@ class ParkingManagementControllerTest {
         }
 
         @Test
-
         void 서브페이지조회_성공() throws Exception {
             ParkingManagementSubPageResDto res = new ParkingManagementSubPageResDto();
             ImageDto imageDto1 = new ImageDto();
             ImageDto imageDto2 = new ImageDto();
-            ReflectionTestUtils.setField(imageDto1, "id",1L);
-            ReflectionTestUtils.setField(imageDto1, "image","image1");
-            ReflectionTestUtils.setField(imageDto2, "id",2L);
-            ReflectionTestUtils.setField(imageDto2, "image","image2");
+            ReflectionTestUtils.setField(imageDto1, "id", 1L);
+            ReflectionTestUtils.setField(imageDto1, "image", "image1");
+            ReflectionTestUtils.setField(imageDto2, "id", 2L);
+            ReflectionTestUtils.setField(imageDto2, "image", "image2");
             ReflectionTestUtils.setField(res, "subPageHeaderName", "주차구역 안내");
             ReflectionTestUtils.setField(res, "images", List.of(imageDto1, imageDto2));
 
-            given(parkingManagementService.getParkingManagementSubPage(VALID_ID)).willReturn(res);
+            given(parkingManagementService.getParkingManagementSubPage(VALID_ID))
+                    .willReturn(res);
 
             mockMvc.perform(get("/api/v2/admin/parking-managements/{id}/sub-page-info", VALID_ID)
                             .header("Authorization", ADMIN_TOKEN))

--- a/src/test/java/com/halo/eventer/domain/parking/entity/ParkingManagementTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/entity/ParkingManagementTest.java
@@ -3,15 +3,14 @@ package com.halo.eventer.domain.parking.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.halo.eventer.domain.parking.ParkingManagement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.halo.eventer.domain.festival.Festival;
 import com.halo.eventer.domain.image.Image;
+import com.halo.eventer.domain.parking.ParkingManagement;
 import com.halo.eventer.domain.parking.enums.ParkingInfoType;
 import com.halo.eventer.global.constants.DisplayOrderConstants;
 import com.halo.eventer.global.error.exception.BaseException;
@@ -42,9 +41,8 @@ class ParkingManagementTest {
         boolean visible = true;
 
         // when
-        ParkingManagement pm = ParkingManagement.of(
-                축제, header, infoType, title, description, buttonName, buttonUrl, bg, visible
-        );
+        ParkingManagement pm =
+                ParkingManagement.of(축제, header, infoType, title, description, buttonName, buttonUrl, bg, visible);
 
         // then
         assertThat(pm.getFestival()).isEqualTo(축제);
@@ -63,9 +61,7 @@ class ParkingManagementTest {
     @Test
     void 기본정보_update_호출시_모든_필드가_갱신된다() {
         // given: 초기 엔티티
-        ParkingManagement pm = ParkingManagement.of(
-                축제, "헤더", null, "제목", "설명", "버튼", "url", "bg", true
-        );
+        ParkingManagement pm = ParkingManagement.of(축제, "헤더", null, "제목", "설명", "버튼", "url", "bg", true);
 
         // when
         pm.update("변경헤더", null, "변경제목", "변경설명", "변경버튼", "변경url", "변경bg", false);
@@ -84,9 +80,7 @@ class ParkingManagementTest {
     @Test
     void 서브페이지_헤더명_updateSubPageHeaderName_갱신된다() {
         // given
-        ParkingManagement pm = ParkingManagement.of(
-                축제, "헤더", null, "제목", null, "버튼", null, null, true
-        );
+        ParkingManagement pm = ParkingManagement.of(축제, "헤더", null, "제목", null, "버튼", null, null, true);
 
         // when
         pm.updateSubPageHeaderName("서브헤더");
@@ -126,8 +120,7 @@ class ParkingManagementTest {
             assertThat(pm.getImages()).hasSize(limit);
 
             // when // then
-            assertThatThrownBy(() -> pm.addImage("overflow.jpg"))
-                    .isInstanceOf(BaseException.class);
+            assertThatThrownBy(() -> pm.addImage("overflow.jpg")).isInstanceOf(BaseException.class);
         }
 
         @Test
@@ -165,25 +158,21 @@ class ParkingManagementTest {
             pm.reorderImages(List.of(3L, 1L, 2L));
 
             // then
-            assertThat(pm.getImages()).extracting(Image::getId)
-                    .containsExactly(3L, 1L, 2L);
+            assertThat(pm.getImages()).extracting(Image::getId).containsExactly(3L, 1L, 2L);
         }
 
         @Test
         void 재정렬_ID_중복이_있거나_크기_불일치면_INVALID_INPUT_VALUE() {
             // 크기 불일치
-            assertThatThrownBy(() -> pm.reorderImages(List.of(1L, 2L)))
-                    .isInstanceOf(BaseException.class);
+            assertThatThrownBy(() -> pm.reorderImages(List.of(1L, 2L))).isInstanceOf(BaseException.class);
 
             // 중복
-            assertThatThrownBy(() -> pm.reorderImages(List.of(1L, 1L, 2L)))
-                    .isInstanceOf(BaseException.class);
+            assertThatThrownBy(() -> pm.reorderImages(List.of(1L, 1L, 2L))).isInstanceOf(BaseException.class);
         }
 
         @Test
         void 재정렬_ID에_없는_ID가_포함되면_INVALID_INPUT_VALUE() {
-            assertThatThrownBy(() -> pm.reorderImages(List.of(999L, 1L, 2L)))
-                    .isInstanceOf(BaseException.class);
+            assertThatThrownBy(() -> pm.reorderImages(List.of(999L, 1L, 2L))).isInstanceOf(BaseException.class);
         }
     }
 

--- a/src/test/java/com/halo/eventer/domain/parking/entity/ParkingManagementTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/entity/ParkingManagementTest.java
@@ -1,0 +1,201 @@
+package com.halo.eventer.domain.parking.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.halo.eventer.domain.parking.ParkingManagement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.image.Image;
+import com.halo.eventer.domain.parking.enums.ParkingInfoType;
+import com.halo.eventer.global.constants.DisplayOrderConstants;
+import com.halo.eventer.global.error.exception.BaseException;
+
+import static com.halo.eventer.domain.festival.FestivalFixture.축제_엔티티;
+import static org.assertj.core.api.Assertions.*;
+
+@SuppressWarnings("NonAsciiCharacters")
+class ParkingManagementTest {
+
+    private Festival 축제;
+
+    @BeforeEach
+    void setUp() {
+        축제 = 축제_엔티티();
+    }
+
+    @Test
+    void 정적팩토리_of_생성시_축제와_양방향_연결된다() {
+        // given
+        String header = "주차안내";
+        ParkingInfoType infoType = ParkingInfoType.BASIC;
+        String title = "주차장 이용 방법";
+        String description = "설명";
+        String buttonName = "자세히";
+        String buttonUrl = "https://example.com";
+        String bg = "bg.jpg";
+        boolean visible = true;
+
+        // when
+        ParkingManagement pm = ParkingManagement.of(
+                축제, header, infoType, title, description, buttonName, buttonUrl, bg, visible
+        );
+
+        // then
+        assertThat(pm.getFestival()).isEqualTo(축제);
+        assertThat(축제.getParkingManagements()).contains(pm);
+
+        assertThat(pm.getHeaderName()).isEqualTo(header);
+        assertThat(pm.getParkingInfoType()).isEqualTo(infoType);
+        assertThat(pm.getTitle()).isEqualTo(title);
+        assertThat(pm.getDescription()).isEqualTo(description);
+        assertThat(pm.getButtonName()).isEqualTo(buttonName);
+        assertThat(pm.getButtonTargetUrl()).isEqualTo(buttonUrl);
+        assertThat(pm.getBackgroundImage()).isEqualTo(bg);
+        assertThat(pm.isVisible()).isTrue();
+    }
+
+    @Test
+    void 기본정보_update_호출시_모든_필드가_갱신된다() {
+        // given: 초기 엔티티
+        ParkingManagement pm = ParkingManagement.of(
+                축제, "헤더", null, "제목", "설명", "버튼", "url", "bg", true
+        );
+
+        // when
+        pm.update("변경헤더", null, "변경제목", "변경설명", "변경버튼", "변경url", "변경bg", false);
+
+        // then
+        assertThat(pm.getHeaderName()).isEqualTo("변경헤더");
+        assertThat(pm.getParkingInfoType()).isNull();
+        assertThat(pm.getTitle()).isEqualTo("변경제목");
+        assertThat(pm.getDescription()).isEqualTo("변경설명");
+        assertThat(pm.getButtonName()).isEqualTo("변경버튼");
+        assertThat(pm.getButtonTargetUrl()).isEqualTo("변경url");
+        assertThat(pm.getBackgroundImage()).isEqualTo("변경bg");
+        assertThat(pm.isVisible()).isFalse();
+    }
+
+    @Test
+    void 서브페이지_헤더명_updateSubPageHeaderName_갱신된다() {
+        // given
+        ParkingManagement pm = ParkingManagement.of(
+                축제, "헤더", null, "제목", null, "버튼", null, null, true
+        );
+
+        // when
+        pm.updateSubPageHeaderName("서브헤더");
+
+        // then
+        assertThat(pm.getSubPageHeaderName()).isEqualTo("서브헤더");
+    }
+
+    @Nested
+    class 이미지_추가_제거 {
+
+        ParkingManagement pm;
+
+        @BeforeEach
+        void init() {
+            pm = ParkingManagement.of(축제, "헤더", null, "제목", null, "버튼", null, null, true);
+        }
+
+        @Test
+        void addImage_호출시_이미지_목록에_추가된다() {
+            // when
+            pm.addImage("img1.jpg");
+            pm.addImage("img2.jpg");
+
+            // then
+            assertThat(pm.getImages()).hasSize(2);
+            assertThat(pm.getImages()).extracting("parkingManagement").containsOnly(pm);
+        }
+
+        @Test
+        void 이미지_개수_상한_초과시_MAX_COUNT_EXCEEDED_예외() {
+            // given
+            int limit = DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE;
+            for (int i = 0; i < limit; i++) {
+                pm.addImage("img-" + i + ".jpg");
+            }
+            assertThat(pm.getImages()).hasSize(limit);
+
+            // when // then
+            assertThatThrownBy(() -> pm.addImage("overflow.jpg"))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void removeImages_호출시_ID에_해당하는_이미지가_제거된다() {
+            pm.addImage("a.jpg");
+            pm.addImage("b.jpg");
+            pm.addImage("c.jpg");
+            setImageIds(pm, 10L, 20L, 30L);
+
+            pm.removeImages(List.of(10L, 30L));
+
+            assertThat(pm.getImages()).hasSize(1);
+            assertThat(pm.getImages()).extracting(Image::getId).containsExactly(20L);
+        }
+    }
+
+    @Nested
+    class 이미지_순서_변경 {
+
+        ParkingManagement pm;
+
+        @BeforeEach
+        void init() {
+            pm = ParkingManagement.of(축제, "헤더", null, "제목", null, "버튼", null, null, true);
+            pm.addImage("1.jpg");
+            pm.addImage("2.jpg");
+            pm.addImage("3.jpg");
+            // 재정렬 검증을 위해 이미지 ID를 세팅한다 (JPA 미사용 환경)
+            setImageIds(pm, 1L, 2L, 3L);
+        }
+
+        @Test
+        void reorderImages_성공시_리스트_순서가_ID_순서대로_변경된다() {
+            // when
+            pm.reorderImages(List.of(3L, 1L, 2L));
+
+            // then
+            assertThat(pm.getImages()).extracting(Image::getId)
+                    .containsExactly(3L, 1L, 2L);
+        }
+
+        @Test
+        void 재정렬_ID_중복이_있거나_크기_불일치면_INVALID_INPUT_VALUE() {
+            // 크기 불일치
+            assertThatThrownBy(() -> pm.reorderImages(List.of(1L, 2L)))
+                    .isInstanceOf(BaseException.class);
+
+            // 중복
+            assertThatThrownBy(() -> pm.reorderImages(List.of(1L, 1L, 2L)))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 재정렬_ID에_없는_ID가_포함되면_INVALID_INPUT_VALUE() {
+            assertThatThrownBy(() -> pm.reorderImages(List.of(999L, 1L, 2L)))
+                    .isInstanceOf(BaseException.class);
+        }
+    }
+
+    /**
+     * 테스트 편의를 위한 유틸:
+     * JPA 없이 도메인 단위 테스트에서 Image id를 강제로 부여해 재정렬/삭제 로직을 검증한다.
+     */
+    private static void setImageIds(ParkingManagement pm, Long... ids) {
+        var images = new ArrayList<>(pm.getImages());
+        assertThat(images.size()).isEqualTo(ids.length);
+        for (int i = 0; i < ids.length; i++) {
+            ReflectionTestUtils.setField(images.get(i), "id", ids[i]);
+        }
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/service/ParkingManagementServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/service/ParkingManagementServiceTest.java
@@ -1,0 +1,341 @@
+package com.halo.eventer.domain.parking.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.festival.exception.FestivalNotFoundException;
+import com.halo.eventer.domain.festival.repository.FestivalRepository;
+import com.halo.eventer.domain.image.dto.FileDto;
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.parking.dto.ParkingManagementReqDto;
+import com.halo.eventer.domain.parking.dto.ParkingManagementResDto;
+import com.halo.eventer.domain.parking.dto.ParkingManagementSubPageResDto;
+import com.halo.eventer.domain.parking.dto.ParkingMapImageReqDto;
+import com.halo.eventer.domain.parking.dto.ParkingSubPageReqDto;
+import com.halo.eventer.domain.parking.enums.ParkingInfoType;
+import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
+import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
+import com.halo.eventer.global.constants.DisplayOrderConstants;
+import com.halo.eventer.global.error.exception.BaseException;
+
+import static com.halo.eventer.domain.festival.FestivalFixture.축제_엔티티;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class ParkingManagementServiceTest {
+
+    @InjectMocks
+    private ParkingManagementService service;
+
+    @Mock
+    private ParkingManagementRepository parkingManagementRepository;
+
+    @Mock
+    private FestivalRepository festivalRepository;
+
+    private Festival 축제;
+
+    @BeforeEach
+    void setUp() {
+        축제 = 축제_엔티티();
+    }
+
+    @Test
+    void 축제에_주차관리_생성_성공() {
+        // given
+        Long 축제_id = 1L;
+        var 요청 = mock(ParkingManagementReqDto.class);
+        String enumName = ParkingInfoType.values()[0].name();
+
+        given(요청.getHeaderName()).willReturn("헤더");
+        given(요청.getParkingInfoType()).willReturn(enumName);
+        given(요청.getTitle()).willReturn("제목");
+        given(요청.getDescription()).willReturn("설명");
+        given(요청.getButtonName()).willReturn("버튼");
+        given(요청.getButtonTargetUrl()).willReturn("url");
+        given(요청.getBackgroundImage()).willReturn("bg.jpg");
+        given(요청.isVisible()).willReturn(true);
+
+        given(festivalRepository.findById(축제_id)).willReturn(Optional.of(축제));
+        given(parkingManagementRepository.save(any(ParkingManagement.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        service.create(축제_id, 요청);
+
+        // then
+        then(festivalRepository).should().findById(축제_id);
+        then(parkingManagementRepository).should().save(any(ParkingManagement.class));
+
+        assertThat(축제.getParkingManagements()).hasSize(1);
+        ParkingManagement saved = 축제.getParkingManagements().get(0);
+        assertThat(saved.getHeaderName()).isEqualTo("헤더");
+        assertThat(saved.getParkingInfoType()).isEqualTo(ParkingInfoType.valueOf(enumName));
+        assertThat(saved.getTitle()).isEqualTo("제목");
+        assertThat(saved.getDescription()).isEqualTo("설명");
+        assertThat(saved.getButtonName()).isEqualTo("버튼");
+        assertThat(saved.getButtonTargetUrl()).isEqualTo("url");
+        assertThat(saved.getBackgroundImage()).isEqualTo("bg.jpg");
+        assertThat(saved.isVisible()).isTrue();
+        assertThat(saved.getFestival()).isEqualTo(축제);
+    }
+
+    @Test
+    void 축제에_주차관리_생성_실패_축제없음() {
+        given(festivalRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.create(1L, mock(ParkingManagementReqDto.class)))
+                .isInstanceOf(FestivalNotFoundException.class);
+
+        then(parkingManagementRepository).should(never()).save(any());
+    }
+
+    @Test
+    void 주차관리_단건_조회_성공() {
+        // given
+        ParkingManagement pm = ParkingManagement.of(
+                축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                "버튼", "url", "bg", true
+        );
+        given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
+
+        // when
+        ParkingManagementResDto res = service.getParkingManagement(1L);
+
+        // then
+        assertThat(res.getHeaderName()).isEqualTo(pm.getHeaderName());
+        assertThat(res.getParkingInfoType()).isEqualTo(pm.getParkingInfoType().name());
+        assertThat(res.getTitle()).isEqualTo(pm.getTitle());
+        assertThat(res.getDescription()).isEqualTo(pm.getDescription());
+        assertThat(res.getButtonName()).isEqualTo(pm.getButtonName());
+        assertThat(res.getButtonTargetUrl()).isEqualTo(pm.getButtonTargetUrl());
+        assertThat(res.getBackgroundImage()).isEqualTo(pm.getBackgroundImage());
+        assertThat(res.isVisible()).isEqualTo(pm.isVisible());
+    }
+
+    @Test
+    void 주차관리_단건_조회_실패_없음() {
+        given(parkingManagementRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getParkingManagement(1L))
+                .isInstanceOf(ParkingManagementNotFoundException.class);
+    }
+
+    @Test
+    void 주차관리_기본정보_수정_성공() {
+        // given
+        ParkingManagement pm = ParkingManagement.of(
+                축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                "버튼", "url", "bg", true
+        );
+        given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
+
+        var 요청 = mock(ParkingManagementReqDto.class);
+        given(요청.getHeaderName()).willReturn("새헤더");
+        given(요청.getParkingInfoType()).willReturn(ParkingInfoType.values()[0].name());
+        given(요청.getTitle()).willReturn("새제목");
+        given(요청.getDescription()).willReturn("새설명");
+        given(요청.getButtonName()).willReturn("새버튼");
+        given(요청.getButtonTargetUrl()).willReturn("새url");
+        given(요청.getBackgroundImage()).willReturn("새bg");
+        given(요청.isVisible()).willReturn(false);
+
+        // when
+        service.update(1L, 요청);
+
+        // then
+        assertThat(pm.getHeaderName()).isEqualTo("새헤더");
+        assertThat(pm.getTitle()).isEqualTo("새제목");
+        assertThat(pm.getDescription()).isEqualTo("새설명");
+        assertThat(pm.getButtonName()).isEqualTo("새버튼");
+        assertThat(pm.getButtonTargetUrl()).isEqualTo("새url");
+        assertThat(pm.getBackgroundImage()).isEqualTo("새bg");
+        assertThat(pm.isVisible()).isFalse();
+    }
+
+    @Test
+    void 주차관리_기본정보_수정_실패_없음() {
+        given(parkingManagementRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update(1L, mock(ParkingManagementReqDto.class)))
+                .isInstanceOf(ParkingManagementNotFoundException.class);
+    }
+
+    @Nested
+    class 서브페이지_및_이미지 {
+
+        @Test
+        void 서브페이지_조회_성공() {
+            ParkingManagement pm = ParkingManagement.of(
+                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                    "버튼", "url", "bg", true
+            );
+            pm.updateSubPageHeaderName("서브");
+            pm.addImage("a.jpg");
+            pm.addImage("b.jpg");
+            given(parkingManagementRepository.findByIdWithImages(1L)).willReturn(Optional.of(pm));
+
+            ParkingManagementSubPageResDto res = service.getParkingManagementSubPage(1L);
+
+            assertThat(res.getSubPageHeaderName()).isEqualTo("서브");
+            assertThat(res.getImages()).hasSize(2);
+        }
+
+        @Test
+        void 서브페이지_조회_실패_없음() {
+            given(parkingManagementRepository.findByIdWithImages(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getParkingManagementSubPage(1L))
+                    .isInstanceOf(ParkingManagementNotFoundException.class);
+        }
+
+        @Test
+        void 서브페이지_헤더명_수정_성공() {
+            ParkingManagement pm = ParkingManagement.of(
+                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                    "버튼", "url", "bg", true
+            );
+            given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
+
+            var 요청 = mock(ParkingSubPageReqDto.class);
+            given(요청.getSubPageHeaderName()).willReturn("새서브");
+
+            service.updateSubPageHeaderName(1L, 요청);
+
+            assertThat(pm.getSubPageHeaderName()).isEqualTo("새서브");
+        }
+
+        @Test
+        void 주차맵_이미지_생성_성공() {
+            ParkingManagement pm = ParkingManagement.of(
+                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                    "버튼", "url", "bg", true
+            );
+            given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
+
+            var 파일 = mock(FileDto.class);
+            given(파일.getUrl()).willReturn("map.jpg");
+
+            service.createParkingMapImage(1L, 파일);
+
+            assertThat(pm.getImages()).hasSize(1);
+            assertThat(pm.getImages().get(0).getParkingManagement()).isEqualTo(pm);
+        }
+
+        @Test
+        void 주차맵_이미지_생성_실패_상한초과() {
+            ParkingManagement pm = ParkingManagement.of(
+                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                    "버튼", "url", "bg", true
+            );
+            int limit = DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE;
+            for (int i = 0; i < limit; i++) pm.addImage("img-" + i);
+
+            given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
+
+            var 파일 = mock(FileDto.class);
+            given(파일.getUrl()).willReturn("overflow.jpg");
+
+            assertThatThrownBy(() -> service.createParkingMapImage(1L, 파일))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 이미지_표시순서_변경_성공() {
+            ParkingManagement pm = ParkingManagement.of(
+                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                    "버튼", "url", "bg", true
+            );
+            pm.addImage("1.jpg");
+            pm.addImage("2.jpg");
+            pm.addImage("3.jpg");
+            ReflectionTestUtils.setField(pm.getImages().get(0), "id", 10L);
+            ReflectionTestUtils.setField(pm.getImages().get(1), "id", 20L);
+            ReflectionTestUtils.setField(pm.getImages().get(2), "id", 30L);
+
+            given(parkingManagementRepository.findByIdWithImages(1L)).willReturn(Optional.of(pm));
+
+            var 요청 = mock(ParkingMapImageReqDto.class);
+            given(요청.getImageIds()).willReturn(List.of(30L, 10L, 20L));
+
+            service.updateParkingMapImageDisplayOrder(1L, 요청);
+
+            assertThat(pm.getImages())
+                    .extracting(img -> (Long) ReflectionTestUtils.getField(img, "id"))
+                    .containsExactly(30L, 10L, 20L);
+        }
+
+        @Test
+        void 이미지_표시순서_변경_실패_주차관리없음() {
+            given(parkingManagementRepository.findByIdWithImages(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.updateParkingMapImageDisplayOrder(1L, mock(ParkingMapImageReqDto.class)))
+                    .isInstanceOf(ParkingManagementNotFoundException.class);
+        }
+
+        @Test
+        void 이미지_표시순서_변경_실패_검증오류() {
+            ParkingManagement pm = ParkingManagement.of(
+                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                    "버튼", "url", "bg", true
+            );
+            pm.addImage("1.jpg");
+            pm.addImage("2.jpg");
+            ReflectionTestUtils.setField(pm.getImages().get(0), "id", 1L);
+            ReflectionTestUtils.setField(pm.getImages().get(1), "id", 2L);
+
+            given(parkingManagementRepository.findByIdWithImages(1L)).willReturn(Optional.of(pm));
+
+            var 요청 = mock(ParkingMapImageReqDto.class);
+            given(요청.getImageIds()).willReturn(List.of(1L)); // 크기 불일치
+
+            assertThatThrownBy(() -> service.updateParkingMapImageDisplayOrder(1L, 요청))
+                    .isInstanceOf(BaseException.class);
+        }
+
+        @Test
+        void 이미지_삭제_성공() {
+            ParkingManagement pm = ParkingManagement.of(
+                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
+                    "버튼", "url", "bg", true
+            );
+            pm.addImage("1.jpg");
+            pm.addImage("2.jpg");
+            pm.addImage("3.jpg");
+            ReflectionTestUtils.setField(pm.getImages().get(0), "id", 10L);
+            ReflectionTestUtils.setField(pm.getImages().get(1), "id", 20L);
+            ReflectionTestUtils.setField(pm.getImages().get(2), "id", 30L);
+
+            given(parkingManagementRepository.findByIdWithImages(1L)).willReturn(Optional.of(pm));
+
+            var 요청 = mock(ParkingMapImageReqDto.class);
+            given(요청.getImageIds()).willReturn(List.of(10L, 30L));
+
+            service.deleteParkingMapImages(1L, 요청);
+
+            assertThat(pm.getImages())
+                    .extracting(img -> (Long) ReflectionTestUtils.getField(img, "id"))
+                    .containsExactly(20L);
+        }
+
+        @Test
+        void 이미지_삭제_실패_주차관리없음() {
+            given(parkingManagementRepository.findByIdWithImages(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.deleteParkingMapImages(1L, mock(ParkingMapImageReqDto.class)))
+                    .isInstanceOf(ParkingManagementNotFoundException.class);
+        }
+    }
+}
+

--- a/src/test/java/com/halo/eventer/domain/parking/service/ParkingManagementServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/service/ParkingManagementServiceTest.java
@@ -104,10 +104,8 @@ class ParkingManagementServiceTest {
     @Test
     void 주차관리_단건_조회_성공() {
         // given
-        ParkingManagement pm = ParkingManagement.of(
-                축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                "버튼", "url", "bg", true
-        );
+        ParkingManagement pm =
+                ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
         given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
 
         // when
@@ -135,10 +133,8 @@ class ParkingManagementServiceTest {
     @Test
     void 주차관리_기본정보_수정_성공() {
         // given
-        ParkingManagement pm = ParkingManagement.of(
-                축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                "버튼", "url", "bg", true
-        );
+        ParkingManagement pm =
+                ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
         given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
 
         var 요청 = mock(ParkingManagementReqDto.class);
@@ -177,10 +173,8 @@ class ParkingManagementServiceTest {
 
         @Test
         void 서브페이지_조회_성공() {
-            ParkingManagement pm = ParkingManagement.of(
-                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                    "버튼", "url", "bg", true
-            );
+            ParkingManagement pm =
+                    ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
             pm.updateSubPageHeaderName("서브");
             pm.addImage("a.jpg");
             pm.addImage("b.jpg");
@@ -202,10 +196,8 @@ class ParkingManagementServiceTest {
 
         @Test
         void 서브페이지_헤더명_수정_성공() {
-            ParkingManagement pm = ParkingManagement.of(
-                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                    "버튼", "url", "bg", true
-            );
+            ParkingManagement pm =
+                    ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
             given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
 
             var 요청 = mock(ParkingSubPageReqDto.class);
@@ -218,10 +210,8 @@ class ParkingManagementServiceTest {
 
         @Test
         void 주차맵_이미지_생성_성공() {
-            ParkingManagement pm = ParkingManagement.of(
-                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                    "버튼", "url", "bg", true
-            );
+            ParkingManagement pm =
+                    ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
             given(parkingManagementRepository.findById(1L)).willReturn(Optional.of(pm));
 
             var 파일 = mock(FileDto.class);
@@ -235,10 +225,8 @@ class ParkingManagementServiceTest {
 
         @Test
         void 주차맵_이미지_생성_실패_상한초과() {
-            ParkingManagement pm = ParkingManagement.of(
-                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                    "버튼", "url", "bg", true
-            );
+            ParkingManagement pm =
+                    ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
             int limit = DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE;
             for (int i = 0; i < limit; i++) pm.addImage("img-" + i);
 
@@ -247,16 +235,13 @@ class ParkingManagementServiceTest {
             var 파일 = mock(FileDto.class);
             given(파일.getUrl()).willReturn("overflow.jpg");
 
-            assertThatThrownBy(() -> service.createParkingMapImage(1L, 파일))
-                    .isInstanceOf(BaseException.class);
+            assertThatThrownBy(() -> service.createParkingMapImage(1L, 파일)).isInstanceOf(BaseException.class);
         }
 
         @Test
         void 이미지_표시순서_변경_성공() {
-            ParkingManagement pm = ParkingManagement.of(
-                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                    "버튼", "url", "bg", true
-            );
+            ParkingManagement pm =
+                    ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
             pm.addImage("1.jpg");
             pm.addImage("2.jpg");
             pm.addImage("3.jpg");
@@ -286,10 +271,8 @@ class ParkingManagementServiceTest {
 
         @Test
         void 이미지_표시순서_변경_실패_검증오류() {
-            ParkingManagement pm = ParkingManagement.of(
-                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                    "버튼", "url", "bg", true
-            );
+            ParkingManagement pm =
+                    ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
             pm.addImage("1.jpg");
             pm.addImage("2.jpg");
             ReflectionTestUtils.setField(pm.getImages().get(0), "id", 1L);
@@ -306,10 +289,8 @@ class ParkingManagementServiceTest {
 
         @Test
         void 이미지_삭제_성공() {
-            ParkingManagement pm = ParkingManagement.of(
-                    축제, "헤더", ParkingInfoType.values()[0], "제목", "설명",
-                    "버튼", "url", "bg", true
-            );
+            ParkingManagement pm =
+                    ParkingManagement.of(축제, "헤더", ParkingInfoType.values()[0], "제목", "설명", "버튼", "url", "bg", true);
             pm.addImage("1.jpg");
             pm.addImage("2.jpg");
             pm.addImage("3.jpg");
@@ -338,4 +319,3 @@ class ParkingManagementServiceTest {
         }
     }
 }
-


### PR DESCRIPTION
## #️⃣연관된 이슈

#159 

## 📝작업 내용


### 이전과 달라진 순서 변경 기능

### 이전 
-> displayOrder 필드를 두고 직접 값을 입력받아와 기존 필드 값을 변경하는 형식으로 진행
이전 방식의 문제점
-> 1. 데이터베이스에 순서 값이 중복되어서 저장되고 있음
-> 2. 새로운 요소 추가 같은 경우 실제 기존 데이터를 고려해서 순위 매기는 작업이 번거로움

### 새로운 방식
`@OrderColumn`을 사용하는 방식

-> 일대다 관계에서 One쪽에 연관관계 매핑  필드 (images)에 어노테이션을 붙이고 쓰기지연을 통해 특정 요소의 순서 변경을 쉽게 진행할 수 있다.

쓰기 지연의 경우 다수의 데이터를 변경할 때 N번의 데이터베이스 접근이 발생할 수 있기 때문에 batch_size 옵션을 통해 아래와 같이 하나의 Batch로 데이터베이스 전송하는 것을 수정, 추가, 삭제 로직에서 모두 확인하였습니다.
기능의 단점이 있다면 새로운 이미지를 추가할 때, 이미지를 먼저 추가하고 update 쿼리를 날리기 때문에 쿼리가 불필요하게 2번 발생하는 점
하지만, 구현이 그만큼 매우 쉽기 때문에 이 방식을 선택하게 되었습니다.

<img width="838" height="268" alt="스크린샷 2025-08-19 200520" src="https://github.com/user-attachments/assets/2c663893-1400-4828-98a3-2550bae6c989" />

---

진행하지 못한 것

-> Repository 관련 테스트 코드를 작성하지 못했습니다. 쓰기 지연으로 순서를 변경하는 로직의 경우 따로 직접 PostMan을 통해 테스트를 진행하였습니다. 추후, 테스트 코드를 추가하려고 합니다.


