### PR TITLE
[feat] 주차 관리 시스템 개발 (주차 안내, 주차 구역, 주차장)

### DIFF
--- a/src/main/java/com/halo/eventer/domain/parking/ParkingLot.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingLot.java
@@ -1,0 +1,143 @@
+package com.halo.eventer.domain.parking;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import jakarta.persistence.*;
+
+import com.halo.eventer.domain.parking.enums.CongestionLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "parking_lot")
+public class ParkingLot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    private String sido;
+    private String sigungu;
+    private String dongmyun;
+    private String roadName;
+    private String roadNumber;
+    private String buildingName;
+
+    private double latitude;
+    private double longitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "congestion_level", nullable = false)
+    private CongestionLevel congestionLevel;
+
+    @Column(name = "visible", nullable = false)
+    private Boolean visible;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parking_zone_id")
+    private ParkingZone parkingZone;
+
+    private ParkingLot(
+            String name,
+            String sido,
+            String sigungu,
+            String dongmyun,
+            String roadName,
+            String roadNumber,
+            String buildingName,
+            double latitude,
+            double longitude,
+            CongestionLevel congestionLevel,
+            Boolean visible) {
+        this.name = name;
+        this.sido = sido;
+        this.sigungu = sigungu;
+        this.dongmyun = dongmyun;
+        this.roadName = roadName;
+        this.roadNumber = roadNumber;
+        this.buildingName = buildingName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.congestionLevel = congestionLevel;
+        this.visible = visible;
+    }
+
+    public static ParkingLot of(
+            String name,
+            String sido,
+            String sigungu,
+            String dongmyun,
+            String roadName,
+            String roadNumber,
+            String buildingName,
+            double latitude,
+            double longitude,
+            ParkingZone parkingZone) {
+        ParkingLot parkingLot = new ParkingLot(
+                name,
+                sido,
+                sigungu,
+                dongmyun,
+                roadName,
+                roadNumber,
+                buildingName,
+                latitude,
+                longitude,
+                CongestionLevel.LOW,
+                true);
+        parkingLot.setParkingZone(parkingZone);
+        return parkingLot;
+    }
+
+    public String getCopyAddress() {
+        return joinWithSpace(this.sido, this.getSigungu(), this.getRoadName(), this.getRoadNumber());
+    }
+
+    public String getDisplayAddress() {
+        String roadAddress = joinWithSpace(this.getRoadName(), this.getRoadNumber());
+        return (buildingName == null || buildingName.isBlank()) ? roadAddress : roadAddress + " (" + buildingName + ")";
+    }
+
+    public void changeVisible(Boolean visible) {
+        this.visible = visible;
+    }
+
+    public void changeCongestionLevel(String congestionLevel) {
+        this.congestionLevel = CongestionLevel.valueOf(congestionLevel);
+    }
+
+    public void updateContent(
+            String name,
+            String sido,
+            String sigungu,
+            String dongmyun,
+            String roadName,
+            String roadNumber,
+            String buildingName,
+            double latitude,
+            double longitude) {
+        this.name = name;
+        this.sido = sido;
+        this.sigungu = sigungu;
+        this.dongmyun = dongmyun;
+        this.roadName = roadName;
+        this.roadNumber = roadNumber;
+        this.buildingName = buildingName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    private void setParkingZone(ParkingZone parkingZone) {
+        this.parkingZone = parkingZone;
+        parkingZone.addParkingLot(this);
+    }
+
+    private static String joinWithSpace(String... parts) {
+        return Arrays.stream(parts).filter(p -> p != null && !p.isBlank()).collect(Collectors.joining(" "));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
@@ -52,13 +52,16 @@ public class ParkingManagement {
     @Column(name = "visible", nullable = false)
     private boolean visible = true;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_id")
     private Festival festival;
 
     @OrderColumn(name = "display_order")
     @OneToMany(mappedBy = "parkingManagement", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "parkingManagement", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<ParkingNotice> parkingNotices = new ArrayList<>();
 
     private ParkingManagement(
             Festival festival,
@@ -132,6 +135,10 @@ public class ParkingManagement {
         validateImageCount();
         Image image = Image.ofParkingManagement(imageUrl, this);
         images.add(image);
+    }
+
+    public void addParkingNotice(ParkingNotice parkingNotice) {
+        parkingNotices.add(parkingNotice);
     }
 
     public void reorderImages(List<Long> orderedIds) {

--- a/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingManagement.java
@@ -60,6 +60,10 @@ public class ParkingManagement {
     @OneToMany(mappedBy = "parkingManagement", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
+    @OrderColumn(name = "display_order")
+    @OneToMany(mappedBy = "parkingManagement", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ParkingZone> parkingZones = new ArrayList<>();
+
     @OneToMany(mappedBy = "parkingManagement", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<ParkingNotice> parkingNotices = new ArrayList<>();
 
@@ -141,6 +145,26 @@ public class ParkingManagement {
         parkingNotices.add(parkingNotice);
     }
 
+    public void addParkingZone(ParkingZone parkingZone) {
+        validateZoneCount();
+        parkingZones.add(parkingZone);
+    }
+
+    public void reorderParkingZones(List<Long> orderedIds) {
+        validateReorderIdsDuplicationAndSizeForZone(orderedIds);
+        validateNoMissingIdsForZone(orderedIds);
+
+        Map<Long, Integer> rank = new HashMap<>();
+        for (int i = 0; i < orderedIds.size(); i++) {
+            rank.put(orderedIds.get(i), i);
+        }
+        parkingZones.sort(Comparator.comparingInt((ParkingZone zone) -> rank.get(zone.getId())));
+    }
+
+    public void removeParkingZone(Long parkingZoneId) {
+        parkingZones.removeIf(parkingZone -> parkingZoneId == parkingZone.getId());
+    }
+
     public void reorderImages(List<Long> orderedIds) {
         validateReorderIdsDuplicationAndSize(orderedIds);
         validateNoMissingIds(orderedIds);
@@ -153,8 +177,8 @@ public class ParkingManagement {
     }
 
     public void removeImages(List<Long> imageIds) {
-        Set<Long> removdIds = new HashSet<>(imageIds);
-        images.removeIf(image -> removdIds.contains(image.getId()));
+        Set<Long> removedIds = new HashSet<>(imageIds);
+        images.removeIf(image -> removedIds.contains(image.getId()));
     }
 
     private void validateReorderIdsDuplicationAndSize(List<Long> orderedIds) {
@@ -175,6 +199,28 @@ public class ParkingManagement {
 
     private void validateImageCount() {
         if (images.size() >= DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE) {
+            throw new BaseException(ErrorCode.MAX_COUNT_EXCEEDED);
+        }
+    }
+
+    private void validateReorderIdsDuplicationAndSizeForZone(List<Long> orderedIds) {
+        Set<Long> targets = new HashSet<>(orderedIds);
+        if (targets.size() != orderedIds.size() || targets.size() != parkingZones.size()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateNoMissingIdsForZone(List<Long> orderedIds) {
+        Set<Long> existingIds = parkingZones.stream().map(ParkingZone::getId).collect(Collectors.toSet());
+        List<Long> unknown =
+                orderedIds.stream().filter(id -> !existingIds.contains(id)).toList();
+        if (!unknown.isEmpty()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateZoneCount() {
+        if (parkingZones.size() >= DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE) {
             throw new BaseException(ErrorCode.MAX_COUNT_EXCEEDED);
         }
     }

--- a/src/main/java/com/halo/eventer/domain/parking/ParkingNotice.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingNotice.java
@@ -1,0 +1,57 @@
+package com.halo.eventer.domain.parking;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "parking_notice")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ParkingNotice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "content", nullable = false, length = 1000)
+    private String content;
+
+    @Column(name = "visible", nullable = false)
+    private Boolean visible;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parking_management_id")
+    private ParkingManagement parkingManagement;
+
+    private ParkingNotice(String title, String content, Boolean visible) {
+        this.title = title;
+        this.content = content;
+        this.visible = visible;
+    }
+
+    public void updateNotice(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public void changeVisible(Boolean visible) {
+        this.visible = visible;
+    }
+
+    public static ParkingNotice of(String title, String content, Boolean visible, ParkingManagement parkingManagement) {
+        ParkingNotice parkingNotice = new ParkingNotice(title, content, visible);
+        parkingNotice.setParkingManagement(parkingManagement);
+        return parkingNotice;
+    }
+
+    private void setParkingManagement(ParkingManagement parkingManagement) {
+        this.parkingManagement = parkingManagement;
+        parkingManagement.addParkingNotice(this);
+    }
+
+}

--- a/src/main/java/com/halo/eventer/domain/parking/ParkingNotice.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingNotice.java
@@ -1,6 +1,7 @@
 package com.halo.eventer.domain.parking;
 
 import jakarta.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,10 +29,10 @@ public class ParkingNotice {
     @JoinColumn(name = "parking_management_id")
     private ParkingManagement parkingManagement;
 
-    private ParkingNotice(String title, String content, Boolean visible) {
+    private ParkingNotice(String title, String content) {
         this.title = title;
         this.content = content;
-        this.visible = visible;
+        this.visible = true;
     }
 
     public void updateNotice(String title, String content) {
@@ -43,8 +44,8 @@ public class ParkingNotice {
         this.visible = visible;
     }
 
-    public static ParkingNotice of(String title, String content, Boolean visible, ParkingManagement parkingManagement) {
-        ParkingNotice parkingNotice = new ParkingNotice(title, content, visible);
+    public static ParkingNotice of(String title, String content, ParkingManagement parkingManagement) {
+        ParkingNotice parkingNotice = new ParkingNotice(title, content);
         parkingNotice.setParkingManagement(parkingManagement);
         return parkingNotice;
     }
@@ -53,5 +54,4 @@ public class ParkingNotice {
         this.parkingManagement = parkingManagement;
         parkingManagement.addParkingNotice(this);
     }
-
 }

--- a/src/main/java/com/halo/eventer/domain/parking/ParkingZone.java
+++ b/src/main/java/com/halo/eventer/domain/parking/ParkingZone.java
@@ -1,0 +1,105 @@
+package com.halo.eventer.domain.parking;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import jakarta.persistence.*;
+
+import com.halo.eventer.global.constants.DisplayOrderConstants;
+import com.halo.eventer.global.error.ErrorCode;
+import com.halo.eventer.global.error.exception.BaseException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "parking_zone")
+public class ParkingZone {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Boolean visible;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parking_management_id")
+    private ParkingManagement parkingManagement;
+
+    @OrderColumn(name = "display_order")
+    @OneToMany(mappedBy = "parkingZone", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ParkingLot> parkingLots = new ArrayList<>();
+
+    private ParkingZone(String name, Boolean visible) {
+        this.name = name;
+        this.visible = visible;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void changeVisible(Boolean visible) {
+        this.visible = visible;
+    }
+
+    public void changeAllVisible(Boolean visible) {
+        this.parkingLots.forEach(parkingLot -> parkingLot.changeVisible(visible));
+    }
+
+    public static ParkingZone of(String name, Boolean visible, ParkingManagement parkingManagement) {
+        ParkingZone parkingZone = new ParkingZone(name, visible);
+        parkingZone.setParkingManagement(parkingManagement);
+        return parkingZone;
+    }
+
+    public void addParkingLot(ParkingLot parkingLot) {
+        validateParkingLotCount();
+        this.parkingLots.add(parkingLot);
+    }
+
+    private void setParkingManagement(ParkingManagement parkingManagement) {
+        this.parkingManagement = parkingManagement;
+        parkingManagement.addParkingZone(this);
+    }
+
+    public void reorderParkingLot(List<Long> orderedIds) {
+        validateReorderIdsDuplicationAndSize(orderedIds);
+        validateNoMissingIds(orderedIds);
+
+        Map<Long, Integer> rank = new HashMap<>();
+        for (int i = 0; i < orderedIds.size(); i++) {
+            rank.put(orderedIds.get(i), i);
+        }
+        parkingLots.sort(Comparator.comparingInt((ParkingLot parkingLot) -> rank.get(parkingLot.getId())));
+    }
+
+    public void removeParkingLot(Long parkingLotId) {
+        parkingLots.removeIf(parkingLot -> parkingLotId == parkingLot.getId());
+    }
+
+    private void validateReorderIdsDuplicationAndSize(List<Long> orderedIds) {
+        Set<Long> targets = new HashSet<>(orderedIds);
+        if (targets.size() != orderedIds.size() || targets.size() != parkingLots.size()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateNoMissingIds(List<Long> orderedIds) {
+        Set<Long> existingIds = parkingLots.stream().map(ParkingLot::getId).collect(Collectors.toSet());
+        List<Long> unknown =
+                orderedIds.stream().filter(id -> !existingIds.contains(id)).toList();
+        if (!unknown.isEmpty()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateParkingLotCount() {
+        if (parkingLots.size() >= DisplayOrderConstants.DISPLAY_ORDER_LIMIT_VALUE) {
+            throw new BaseException(ErrorCode.MAX_COUNT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/controller/ParkingLotController.java
+++ b/src/main/java/com/halo/eventer/domain/parking/controller/ParkingLotController.java
@@ -1,0 +1,53 @@
+package com.halo.eventer.domain.parking.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.AdminParkingLotResDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.CongestionLevelReqDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.ParkingLotReqDto;
+import com.halo.eventer.domain.parking.service.ParkingLotService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2")
+public class ParkingLotController {
+
+    private final ParkingLotService parkingLotService;
+
+    @PostMapping("/admin/parking-zones/{parkingZoneId}/parking-lots")
+    public void create(
+            @PathVariable("parkingZoneId") Long parkingZoneId, @RequestBody ParkingLotReqDto parkingLotReqDto) {
+        parkingLotService.create(parkingZoneId, parkingLotReqDto);
+    }
+
+    @GetMapping("/admin/parking-lots/{id}")
+    public AdminParkingLotResDto getParkingLot(@PathVariable("id") @Min(1) Long id) {
+        return parkingLotService.getParkingLot(id);
+    }
+
+    @PatchMapping("/admin/parking-lots/{id}/visibility")
+    public void changeVisible(@PathVariable("id") @Min(1) Long id, @RequestBody @Valid VisibilityChangeReqDto reqDto) {
+        parkingLotService.changeVisible(id, reqDto);
+    }
+
+    @PutMapping("/admin/parking-lots/{id}")
+    public void updateContent(@PathVariable("id") @Min(1) Long id, @RequestBody ParkingLotReqDto reqDto) {
+        parkingLotService.updateContent(id, reqDto);
+    }
+
+    @PatchMapping("/admin/parking-lots/{id}/congestion-level")
+    public void changeCongestionLevel(
+            @PathVariable("id") @Min(1) Long id, @RequestBody @Valid CongestionLevelReqDto reqDto) {
+        parkingLotService.changeCongestionLevel(id, reqDto);
+    }
+
+    @DeleteMapping("/admin/parking-lots/{id}")
+    public void delete(@PathVariable("id") @Min(1) Long id) {
+        parkingLotService.delete(id);
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/controller/ParkingManagementController.java
+++ b/src/main/java/com/halo/eventer/domain/parking/controller/ParkingManagementController.java
@@ -6,7 +6,11 @@ import jakarta.validation.constraints.Min;
 import org.springframework.web.bind.annotation.*;
 
 import com.halo.eventer.domain.image.dto.FileDto;
-import com.halo.eventer.domain.parking.dto.*;
+import com.halo.eventer.domain.parking.dto.common.DisplayOrderChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementReqDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementResDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementSubPageResDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingSubPageReqDto;
 import com.halo.eventer.domain.parking.service.ParkingManagementService;
 import lombok.RequiredArgsConstructor;
 
@@ -24,9 +28,14 @@ public class ParkingManagementController {
         parkingManagementService.create(festivalId, parkingManagementReqDto);
     }
 
-    @GetMapping("/common/parking-managements/{id}")
+    @GetMapping("/admin/parking-managements/{id}")
     public ParkingManagementResDto getParkingManagement(@PathVariable("id") Long id) {
         return parkingManagementService.getParkingManagement(id);
+    }
+
+    @GetMapping("/user/parking-managements/{id}")
+    public ParkingManagementResDto getParkingManagementByUserId(@PathVariable("id") Long id) {
+        return parkingManagementService.getVisibleParkingManagement(id);
     }
 
     @PutMapping("/admin/parking-managements/{id}")
@@ -54,13 +63,15 @@ public class ParkingManagementController {
 
     @PatchMapping("/admin/parking-managements/{id}/parking-map-images/display-order")
     public void updateParkingMapImageDisplayOrder(
-            @Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto) {
-        parkingManagementService.updateParkingMapImageDisplayOrder(id, parkingMapImageReqDto);
+            @Min(1) @PathVariable("id") Long id,
+            @Valid @RequestBody DisplayOrderChangeReqDto displayOrderChangeReqDto) {
+        parkingManagementService.updateParkingMapImageDisplayOrder(id, displayOrderChangeReqDto);
     }
 
     @DeleteMapping("/admin/parking-managements/{id}/parking-map-images")
     public void deleteParkingMapImages(
-            @Min(1) @PathVariable("id") Long id, @Valid @RequestBody ParkingMapImageReqDto parkingMapImageReqDto) {
-        parkingManagementService.deleteParkingMapImages(id, parkingMapImageReqDto);
+            @Min(1) @PathVariable("id") Long id,
+            @Valid @RequestBody DisplayOrderChangeReqDto displayOrderChangeReqDto) {
+        parkingManagementService.deleteParkingMapImages(id, displayOrderChangeReqDto);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/parking/controller/ParkingNoticeController.java
+++ b/src/main/java/com/halo/eventer/domain/parking/controller/ParkingNoticeController.java
@@ -1,0 +1,58 @@
+package com.halo.eventer.domain.parking.controller;
+
+import java.util.List;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeContentReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeResDto;
+import com.halo.eventer.domain.parking.service.ParkingNoticeService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2")
+public class ParkingNoticeController {
+
+    private final ParkingNoticeService parkingNoticeService;
+
+    @PostMapping("/admin/parking-managements/{parkingManagementId}/parking-notices")
+    public void create(
+            @Min(1) @PathVariable("parkingManagementId") Long parkingManagementId,
+            @Valid @RequestBody ParkingNoticeReqDto parkingNoticeReqDto) {
+        parkingNoticeService.create(parkingManagementId, parkingNoticeReqDto);
+    }
+
+    @GetMapping("/admin/parking-managements/{parkingManagementId}/parking-notices")
+    public List<ParkingNoticeResDto> getParkingNotices(
+            @Min(1) @PathVariable("parkingManagementId") Long parkingManagementId) {
+        return parkingNoticeService.getParkingNotices(parkingManagementId);
+    }
+
+    @GetMapping("/user/parking-notices/{id}")
+    public List<ParkingNoticeResDto> getParkingNotice(@Min(1) @PathVariable("id") Long id) {
+        return parkingNoticeService.getVisibleParkingNotices(id);
+    }
+
+    @PatchMapping(("/admin/parking-notices/{id}/content"))
+    public void updateContent(
+            @Min(1) @PathVariable("id") Long id,
+            @Valid @RequestBody ParkingNoticeContentReqDto parkingNoticeContentReqDto) {
+        parkingNoticeService.updateContent(id, parkingNoticeContentReqDto);
+    }
+
+    @PatchMapping("/admin/parking-notices/{id}/visibility")
+    public void changeVisibility(
+            @Min(1) @PathVariable("id") Long id, @Valid @RequestBody VisibilityChangeReqDto visibilityChangeReqDto) {
+        parkingNoticeService.changeVisibility(id, visibilityChangeReqDto);
+    }
+
+    @DeleteMapping("/admin/parking-notices/{id}")
+    public void delete(@Min(1) @PathVariable("id") Long id) {
+        parkingNoticeService.delete(id);
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/controller/ParkingZoneController.java
+++ b/src/main/java/com/halo/eventer/domain/parking/controller/ParkingZoneController.java
@@ -1,0 +1,61 @@
+package com.halo.eventer.domain.parking.controller;
+
+import java.util.List;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.halo.eventer.domain.parking.dto.common.DisplayOrderChangeReqDto;
+import com.halo.eventer.domain.parking.dto.common.NameUpdateReqDto;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_zone.ParkingZoneReqDto;
+import com.halo.eventer.domain.parking.dto.parking_zone.ParkingZoneResDto;
+import com.halo.eventer.domain.parking.service.ParkingZoneService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2")
+public class ParkingZoneController {
+
+    private final ParkingZoneService parkingZoneService;
+
+    @PostMapping("/admin/parking-managements/{parkingManagementId}/parking-zones")
+    public void create(
+            @PathVariable @Min(1) Long parkingManagementId, @RequestBody @Valid ParkingZoneReqDto parkingZoneReqDto) {
+        parkingZoneService.create(parkingManagementId, parkingZoneReqDto);
+    }
+
+    @GetMapping("/admin/parking-managements/{parkingManagementId}/parking-zones")
+    public List<ParkingZoneResDto> getParkingZones(@PathVariable @Min(1) Long parkingManagementId) {
+        return parkingZoneService.getParkingZones(parkingManagementId);
+    }
+
+    @GetMapping("/user/parking-managements/{parkingManagementId}/parking-zones")
+    public List<ParkingZoneResDto> getVisibleParkingZones(@PathVariable @Min(1) Long parkingManagementId) {
+        return parkingZoneService.getVisibleParkingZones(parkingManagementId);
+    }
+
+    @PatchMapping("/admin/parking-zones/{id}/visibility")
+    public void changeVisibility(
+            @PathVariable("id") @Min(1) Long id, @RequestBody @Valid VisibilityChangeReqDto reqDto) {
+        parkingZoneService.changeVisible(id, reqDto);
+    }
+
+    @PatchMapping("/admin/parking-zones/{id}/name")
+    public void changeName(@PathVariable("id") @Min(1) Long id, @RequestBody @Valid NameUpdateReqDto reqDto) {
+        parkingZoneService.changeName(id, reqDto);
+    }
+
+    @PutMapping("/admin/parking-managements/{parkingManagementId}/parking-zones/display-order")
+    public void changeDisplayOrder(
+            @PathVariable @Min(1) Long parkingManagementId, @RequestBody @Valid DisplayOrderChangeReqDto reqDto) {
+        parkingZoneService.changeDisplayOrder(parkingManagementId, reqDto);
+    }
+
+    @DeleteMapping("/admin/parking-managements/{parkingManagementId}/parking-zones/{id}")
+    public void delete(@PathVariable @Min(1) Long parkingManagementId, @PathVariable("id") @Min(1) Long id) {
+        parkingZoneService.delete(parkingManagementId, id);
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/common/DisplayOrderChangeReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/common/DisplayOrderChangeReqDto.java
@@ -1,4 +1,4 @@
-package com.halo.eventer.domain.parking.dto;
+package com.halo.eventer.domain.parking.dto.common;
 
 import java.util.List;
 import jakarta.validation.constraints.Min;
@@ -9,6 +9,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ParkingMapImageReqDto {
-    private @NotNull List<@Min(1) Long> imageIds;
+public class DisplayOrderChangeReqDto {
+    private @NotNull List<@Min(1) Long> ids;
 }

--- a/src/main/java/com/halo/eventer/domain/parking/dto/common/NameUpdateReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/common/NameUpdateReqDto.java
@@ -1,0 +1,14 @@
+package com.halo.eventer.domain.parking.dto.common;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NameUpdateReqDto {
+
+    @NotEmpty
+    private String name;
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/common/VisibilityChangeReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/common/VisibilityChangeReqDto.java
@@ -1,0 +1,18 @@
+package com.halo.eventer.domain.parking.dto.common;
+
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VisibilityChangeReqDto {
+
+    @NotNull
+    private Boolean visible;
+
+    public VisibilityChangeReqDto(Boolean visible) {
+        this.visible = visible;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/AdminParkingLotResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/AdminParkingLotResDto.java
@@ -1,0 +1,42 @@
+package com.halo.eventer.domain.parking.dto.parking_lot;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminParkingLotResDto {
+    private Long id;
+    private String name;
+    private String sido;
+    private String sigungu;
+    private String dongmyun;
+    private String roadName;
+    private String roadNumber;
+    private String buildingName;
+    private double latitude;
+    private double longitude;
+
+    public AdminParkingLotResDto(
+            Long id,
+            String name,
+            String sido,
+            String sigungu,
+            String dongmyun,
+            String roadName,
+            String roadNumber,
+            String buildingName,
+            double latitude,
+            double longitude) {
+        this.id = id;
+        this.name = name;
+        this.sido = sido;
+        this.sigungu = sigungu;
+        this.dongmyun = dongmyun;
+        this.roadName = roadName;
+        this.roadNumber = roadNumber;
+        this.buildingName = buildingName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/CongestionLevelReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/CongestionLevelReqDto.java
@@ -1,0 +1,18 @@
+package com.halo.eventer.domain.parking.dto.parking_lot;
+
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CongestionLevelReqDto {
+
+    @NotNull
+    private String congestionLevel;
+
+    public CongestionLevelReqDto(String congestionLevel) {
+        this.congestionLevel = congestionLevel;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/ParkingLotReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/ParkingLotReqDto.java
@@ -1,0 +1,39 @@
+package com.halo.eventer.domain.parking.dto.parking_lot;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingLotReqDto {
+    private String name;
+    private String sido;
+    private String sigungu;
+    private String dongmyun;
+    private String roadName;
+    private String roadNumber;
+    private String buildingName;
+    private double latitude;
+    private double longitude;
+
+    public ParkingLotReqDto(
+            String name,
+            String sido,
+            String sigungu,
+            String dongmyun,
+            String roadName,
+            String roadNumber,
+            String buildingName,
+            double latitude,
+            double longitude) {
+        this.name = name;
+        this.sido = sido;
+        this.sigungu = sigungu;
+        this.dongmyun = dongmyun;
+        this.roadName = roadName;
+        this.roadNumber = roadNumber;
+        this.buildingName = buildingName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/ParkingLotSummaryDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_lot/ParkingLotSummaryDto.java
@@ -1,0 +1,25 @@
+package com.halo.eventer.domain.parking.dto.parking_lot;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingLotSummaryDto {
+    private Long id;
+    private String name;
+    private String CongestionLevel;
+    private Boolean visible;
+    private String copyAddress;
+    private String displayAddress;
+
+    public ParkingLotSummaryDto(
+            Long id, String name, String congestionLevel, Boolean visible, String copyAddress, String displayAddress) {
+        this.id = id;
+        this.name = name;
+        CongestionLevel = congestionLevel;
+        this.visible = visible;
+        this.copyAddress = copyAddress;
+        this.displayAddress = displayAddress;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingManagementReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingManagementReqDto.java
@@ -1,21 +1,32 @@
-package com.halo.eventer.domain.parking.dto;
+package com.halo.eventer.domain.parking.dto.parking_management;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ParkingManagementResDto {
+public class ParkingManagementReqDto {
     private String headerName;
+
+    @NotNull
+    @Pattern(regexp = "BASIC|BUTTON|SIMPLE", message = "parkingInfoType must be one of: BASIC, BUTTON, SIMPLE")
     private String parkingInfoType;
+
     private String title;
     private String description;
     private String buttonName;
     private String buttonTargetUrl;
     private String backgroundImage;
+
+    @NotNull
     private boolean visible;
 
-    private ParkingManagementResDto(
+    @Builder
+    public ParkingManagementReqDto(
             String headerName,
             String parkingInfoType,
             String title,
@@ -32,18 +43,5 @@ public class ParkingManagementResDto {
         this.buttonTargetUrl = buttonTargetUrl;
         this.backgroundImage = backgroundImage;
         this.visible = visible;
-    }
-
-    public static ParkingManagementResDto of(
-            String headerName,
-            String parkingInfoType,
-            String title,
-            String description,
-            String buttonName,
-            String buttonTargetUrl,
-            String backgroundImage,
-            boolean visible) {
-        return new ParkingManagementResDto(
-                headerName, parkingInfoType, title, description, buttonName, buttonTargetUrl, backgroundImage, visible);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingManagementResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingManagementResDto.java
@@ -1,32 +1,23 @@
-package com.halo.eventer.domain.parking.dto;
+package com.halo.eventer.domain.parking.dto.parking_management;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ParkingManagementReqDto {
+public class ParkingManagementResDto {
+    private Long id;
     private String headerName;
-
-    @NotNull
-    @Pattern(regexp = "BASIC|BUTTON|SIMPLE", message = "parkingInfoType must be one of: BASIC, BUTTON, SIMPLE")
     private String parkingInfoType;
-
     private String title;
     private String description;
     private String buttonName;
     private String buttonTargetUrl;
     private String backgroundImage;
-
-    @NotNull
     private boolean visible;
 
-    @Builder
-    public ParkingManagementReqDto(
+    private ParkingManagementResDto(
+            Long id,
             String headerName,
             String parkingInfoType,
             String title,
@@ -35,6 +26,7 @@ public class ParkingManagementReqDto {
             String buttonTargetUrl,
             String backgroundImage,
             boolean visible) {
+        this.id = id;
         this.headerName = headerName;
         this.parkingInfoType = parkingInfoType;
         this.title = title;
@@ -43,5 +35,27 @@ public class ParkingManagementReqDto {
         this.buttonTargetUrl = buttonTargetUrl;
         this.backgroundImage = backgroundImage;
         this.visible = visible;
+    }
+
+    public static ParkingManagementResDto of(
+            Long id,
+            String headerName,
+            String parkingInfoType,
+            String title,
+            String description,
+            String buttonName,
+            String buttonTargetUrl,
+            String backgroundImage,
+            boolean visible) {
+        return new ParkingManagementResDto(
+                id,
+                headerName,
+                parkingInfoType,
+                title,
+                description,
+                buttonName,
+                buttonTargetUrl,
+                backgroundImage,
+                visible);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingManagementSubPageResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingManagementSubPageResDto.java
@@ -1,4 +1,4 @@
-package com.halo.eventer.domain.parking.dto;
+package com.halo.eventer.domain.parking.dto.parking_management;
 
 import java.util.List;
 

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingSubPageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_management/ParkingSubPageReqDto.java
@@ -1,4 +1,4 @@
-package com.halo.eventer.domain.parking.dto;
+package com.halo.eventer.domain.parking.dto.parking_management;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_notice/ParkingNoticeContentReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_notice/ParkingNoticeContentReqDto.java
@@ -7,14 +7,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ParkingNoticeReqDto {
-
+public class ParkingNoticeContentReqDto {
     @NotNull
     private String title;
 
     private String content;
 
-    public ParkingNoticeReqDto(String title, String content) {
+    public ParkingNoticeContentReqDto(String title, String content) {
         this.title = title;
         this.content = content;
     }

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_notice/ParkingNoticeReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_notice/ParkingNoticeReqDto.java
@@ -1,0 +1,16 @@
+package com.halo.eventer.domain.parking.dto.parking_notice;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingNoticeReqDto {
+    private String notice;
+    private String content;
+
+    public ParkingNoticeReqDto(String notice, String content) {
+        this.notice = notice;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_notice/ParkingNoticeResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_notice/ParkingNoticeResDto.java
@@ -1,21 +1,21 @@
 package com.halo.eventer.domain.parking.dto.parking_notice;
 
-import jakarta.validation.constraints.NotNull;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ParkingNoticeReqDto {
+public class ParkingNoticeResDto {
 
-    @NotNull
+    private Long id;
     private String title;
-
     private String content;
+    private Boolean visible;
 
-    public ParkingNoticeReqDto(String title, String content) {
+    public ParkingNoticeResDto(Long id, String title, String content, Boolean visible) {
+        this.id = id;
         this.title = title;
         this.content = content;
+        this.visible = visible;
     }
 }

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_zone/ParkingZoneReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_zone/ParkingZoneReqDto.java
@@ -1,0 +1,18 @@
+package com.halo.eventer.domain.parking.dto.parking_zone;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingZoneReqDto {
+
+    @NotEmpty
+    private String name;
+
+    @NotNull
+    private Boolean visible;
+}

--- a/src/main/java/com/halo/eventer/domain/parking/dto/parking_zone/ParkingZoneResDto.java
+++ b/src/main/java/com/halo/eventer/domain/parking/dto/parking_zone/ParkingZoneResDto.java
@@ -1,0 +1,23 @@
+package com.halo.eventer.domain.parking.dto.parking_zone;
+
+import java.util.List;
+
+import com.halo.eventer.domain.parking.dto.parking_lot.ParkingLotSummaryDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ParkingZoneResDto {
+    private Long id;
+    private String name;
+    private Boolean visible;
+    private List<ParkingLotSummaryDto> parkingLots;
+
+    public ParkingZoneResDto(Long id, String name, Boolean visible, List<ParkingLotSummaryDto> parkingLots) {
+        this.id = id;
+        this.name = name;
+        this.visible = visible;
+        this.parkingLots = parkingLots;
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/enums/CongestionLevel.java
+++ b/src/main/java/com/halo/eventer/domain/parking/enums/CongestionLevel.java
@@ -1,0 +1,8 @@
+package com.halo.eventer.domain.parking.enums;
+
+public enum CongestionLevel {
+    LOW,
+    MEDIUM,
+    HIGH,
+    FULL
+}

--- a/src/main/java/com/halo/eventer/domain/parking/exception/ParkingLotNotFoundException.java
+++ b/src/main/java/com/halo/eventer/domain/parking/exception/ParkingLotNotFoundException.java
@@ -1,0 +1,9 @@
+package com.halo.eventer.domain.parking.exception;
+
+import com.halo.eventer.global.error.exception.EntityNotFoundException;
+
+public class ParkingLotNotFoundException extends EntityNotFoundException {
+    public ParkingLotNotFoundException(Long id) {
+        super(String.format("ParkingLot with %d is not found", id));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/exception/ParkingNoticeNotFoundException.java
+++ b/src/main/java/com/halo/eventer/domain/parking/exception/ParkingNoticeNotFoundException.java
@@ -1,0 +1,9 @@
+package com.halo.eventer.domain.parking.exception;
+
+import com.halo.eventer.global.error.exception.EntityNotFoundException;
+
+public class ParkingNoticeNotFoundException extends EntityNotFoundException {
+    public ParkingNoticeNotFoundException(Long id) {
+        super(String.format("ParkingNotice with %d is not found", id));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/exception/ParkingZoneNotFoundException.java
+++ b/src/main/java/com/halo/eventer/domain/parking/exception/ParkingZoneNotFoundException.java
@@ -1,0 +1,9 @@
+package com.halo.eventer.domain.parking.exception;
+
+import com.halo.eventer.global.error.exception.EntityNotFoundException;
+
+public class ParkingZoneNotFoundException extends EntityNotFoundException {
+    public ParkingZoneNotFoundException(Long id) {
+        super(String.format("ParkingZone with %d is not found", id));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/repository/ParkingLotRepository.java
+++ b/src/main/java/com/halo/eventer/domain/parking/repository/ParkingLotRepository.java
@@ -1,0 +1,7 @@
+package com.halo.eventer.domain.parking.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.halo.eventer.domain.parking.ParkingLot;
+
+public interface ParkingLotRepository extends JpaRepository<ParkingLot, Long> {}

--- a/src/main/java/com/halo/eventer/domain/parking/repository/ParkingManagementRepository.java
+++ b/src/main/java/com/halo/eventer/domain/parking/repository/ParkingManagementRepository.java
@@ -12,4 +12,9 @@ public interface ParkingManagementRepository extends JpaRepository<ParkingManage
 
     @Query("SELECT pm FROM ParkingManagement pm JOIN FETCH pm.images i WHERE pm.id = :id ")
     Optional<ParkingManagement> findByIdWithImages(@Param("id") Long id);
+
+    Optional<ParkingManagement> findByIdAndVisible(Long id, Boolean visible);
+
+    @Query("SELECT pm FROM ParkingManagement pm LEFT JOIN FETCH pm.parkingZones WHERE pm.id = :id ")
+    Optional<ParkingManagement> findByIdWithParkingZone(@Param("id") Long id);
 }

--- a/src/main/java/com/halo/eventer/domain/parking/repository/ParkingNoticeRepository.java
+++ b/src/main/java/com/halo/eventer/domain/parking/repository/ParkingNoticeRepository.java
@@ -1,0 +1,6 @@
+package com.halo.eventer.domain.parking.repository;
+
+import com.halo.eventer.domain.parking.ParkingNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParkingNoticeRepository extends JpaRepository<ParkingNotice, Long> {}

--- a/src/main/java/com/halo/eventer/domain/parking/repository/ParkingNoticeRepository.java
+++ b/src/main/java/com/halo/eventer/domain/parking/repository/ParkingNoticeRepository.java
@@ -1,6 +1,20 @@
 package com.halo.eventer.domain.parking.repository;
 
-import com.halo.eventer.domain.parking.ParkingNotice;
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
-public interface ParkingNoticeRepository extends JpaRepository<ParkingNotice, Long> {}
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.halo.eventer.domain.parking.ParkingNotice;
+
+public interface ParkingNoticeRepository extends JpaRepository<ParkingNotice, Long> {
+
+    @Query("SELECT pn FROM ParkingNotice pn WHERE pn.parkingManagement.id = :parkingManagementId ")
+    List<ParkingNotice> findByIdParkingManagementId(@Param("id") Long parkingManagementId);
+
+    @Query(
+            "SELECT pn FROM ParkingNotice pn WHERE pn.parkingManagement.id = :parkingManagementId AND pn.visible = :visible ")
+    List<ParkingNotice> findByIdParkingManagementIdAndVisible(
+            @Param("id") Long parkingManagementId, @Param("visible") Boolean visible);
+}

--- a/src/main/java/com/halo/eventer/domain/parking/repository/ParkingZoneRepository.java
+++ b/src/main/java/com/halo/eventer/domain/parking/repository/ParkingZoneRepository.java
@@ -1,0 +1,25 @@
+package com.halo.eventer.domain.parking.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.halo.eventer.domain.parking.ParkingZone;
+
+public interface ParkingZoneRepository extends JpaRepository<ParkingZone, Long> {
+
+    @Query(
+            "SELECT pz FROM ParkingZone pz JOIN FETCH pz.parkingManagement pm left join fetch pz.parkingLots pl WHERE pm.id = :parkingManagementId ")
+    List<ParkingZone> findAllByParkingManagementId(@Param("parkingManagementId") Long parkingManagementId);
+
+    @Query(
+            "SELECT pz FROM ParkingZone pz JOIN FETCH pz.parkingManagement pm left join fetch pz.parkingLots pl WHERE pm.id = :parkingManagementId AND pz.visible = :visible ")
+    List<ParkingZone> findAllByParkingManagementIdAndVisible(
+            @Param("parkingManagementId") Long parkingManagementId, @Param("visible") Boolean visible);
+
+    @Query("SELECT pz FROM ParkingZone pz left JOIN fetch pz.parkingLots pl where pz.id = :id ")
+    Optional<ParkingZone> findByIdWithParkingLot(@Param("id") Long id);
+}

--- a/src/main/java/com/halo/eventer/domain/parking/service/ParkingLotService.java
+++ b/src/main/java/com/halo/eventer/domain/parking/service/ParkingLotService.java
@@ -1,0 +1,96 @@
+package com.halo.eventer.domain.parking.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.halo.eventer.domain.parking.ParkingLot;
+import com.halo.eventer.domain.parking.ParkingZone;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.AdminParkingLotResDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.CongestionLevelReqDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.ParkingLotReqDto;
+import com.halo.eventer.domain.parking.exception.ParkingZoneNotFoundException;
+import com.halo.eventer.domain.parking.repository.ParkingLotRepository;
+import com.halo.eventer.domain.parking.repository.ParkingZoneRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ParkingLotService {
+
+    private final ParkingLotRepository parkingLotRepository;
+    private final ParkingZoneRepository parkingZoneRepository;
+
+    @Transactional
+    public void create(final long parkingZoneId, ParkingLotReqDto parkingLotReqDto) {
+        ParkingZone parkingZone = parkingZoneRepository
+                .findById(parkingZoneId)
+                .orElseThrow(() -> new ParkingZoneNotFoundException(parkingZoneId));
+        ParkingLot parkingLot = ParkingLot.of(
+                parkingLotReqDto.getName(),
+                parkingLotReqDto.getSido(),
+                parkingLotReqDto.getSigungu(),
+                parkingLotReqDto.getDongmyun(),
+                parkingLotReqDto.getRoadName(),
+                parkingLotReqDto.getRoadNumber(),
+                parkingLotReqDto.getBuildingName(),
+                parkingLotReqDto.getLatitude(),
+                parkingLotReqDto.getLongitude(),
+                parkingZone);
+    }
+
+    @Transactional(readOnly = true)
+    public AdminParkingLotResDto getParkingLot(final long id) {
+        ParkingLot parkingLot = loadParkingLotOrThrow(id);
+        return new AdminParkingLotResDto(
+                parkingLot.getId(),
+                parkingLot.getName(),
+                parkingLot.getSido(),
+                parkingLot.getSigungu(),
+                parkingLot.getDongmyun(),
+                parkingLot.getRoadName(),
+                parkingLot.getRoadNumber(),
+                parkingLot.getBuildingName(),
+                parkingLot.getLatitude(),
+                parkingLot.getLongitude());
+    }
+
+    @Transactional
+    public void changeVisible(final long id, VisibilityChangeReqDto visibilityChangeReqDto) {
+        ParkingLot parkingLot = loadParkingLotOrThrow(id);
+        parkingLot.changeVisible(visibilityChangeReqDto.getVisible());
+    }
+
+    @Transactional
+    public void updateContent(final long id, ParkingLotReqDto parkingLotReqDto) {
+        ParkingLot parkingLot = loadParkingLotOrThrow(id);
+        parkingLot.updateContent(
+                parkingLotReqDto.getName(),
+                parkingLotReqDto.getSido(),
+                parkingLotReqDto.getSigungu(),
+                parkingLotReqDto.getDongmyun(),
+                parkingLotReqDto.getRoadName(),
+                parkingLotReqDto.getRoadNumber(),
+                parkingLotReqDto.getBuildingName(),
+                parkingLotReqDto.getLatitude(),
+                parkingLotReqDto.getLongitude());
+    }
+
+    @Transactional
+    public void changeCongestionLevel(final long id, CongestionLevelReqDto congestionLevelReqDto) {
+        ParkingLot parkingLot = loadParkingLotOrThrow(id);
+        parkingLot.changeCongestionLevel(congestionLevelReqDto.getCongestionLevel());
+    }
+
+    @Transactional
+    public void delete(final long id) {
+        ParkingLot parkingLot = loadParkingLotOrThrow(id);
+        parkingLotRepository.delete(parkingLot);
+    }
+
+    private ParkingLot loadParkingLotOrThrow(Long id) {
+        return parkingLotRepository.findById(id).orElseThrow(() -> new ParkingZoneNotFoundException(id));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/parking/service/ParkingManagementService.java
+++ b/src/main/java/com/halo/eventer/domain/parking/service/ParkingManagementService.java
@@ -8,7 +8,11 @@ import com.halo.eventer.domain.festival.exception.FestivalNotFoundException;
 import com.halo.eventer.domain.festival.repository.FestivalRepository;
 import com.halo.eventer.domain.image.dto.FileDto;
 import com.halo.eventer.domain.parking.ParkingManagement;
-import com.halo.eventer.domain.parking.dto.*;
+import com.halo.eventer.domain.parking.dto.common.DisplayOrderChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementReqDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementResDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementSubPageResDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingSubPageReqDto;
 import com.halo.eventer.domain.parking.enums.ParkingInfoType;
 import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
 import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
@@ -44,6 +48,24 @@ public class ParkingManagementService {
         ParkingManagement parkingManagement =
                 parkingManagementRepository.findById(id).orElseThrow(() -> new ParkingManagementNotFoundException(id));
         return ParkingManagementResDto.of(
+                parkingManagement.getId(),
+                parkingManagement.getHeaderName(),
+                parkingManagement.getParkingInfoType().name(),
+                parkingManagement.getTitle(),
+                parkingManagement.getDescription(),
+                parkingManagement.getButtonName(),
+                parkingManagement.getButtonTargetUrl(),
+                parkingManagement.getBackgroundImage(),
+                parkingManagement.isVisible());
+    }
+
+    @Transactional(readOnly = true)
+    public ParkingManagementResDto getVisibleParkingManagement(Long id) {
+        ParkingManagement parkingManagement = parkingManagementRepository
+                .findByIdAndVisible(id, true)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(id));
+        return ParkingManagementResDto.of(
+                parkingManagement.getId(),
                 parkingManagement.getHeaderName(),
                 parkingManagement.getParkingInfoType().name(),
                 parkingManagement.getTitle(),
@@ -90,20 +112,20 @@ public class ParkingManagementService {
     }
 
     @Transactional
-    public void updateParkingMapImageDisplayOrder(Long id, ParkingMapImageReqDto parkingMapImageReqDto) {
+    public void updateParkingMapImageDisplayOrder(Long id, DisplayOrderChangeReqDto displayOrderChangeReqDto) {
         ParkingManagement parkingManagement = parkingManagementRepository
                 .findByIdWithImages(id)
                 .orElseThrow(() -> new ParkingManagementNotFoundException(id));
 
-        parkingManagement.reorderImages(parkingMapImageReqDto.getImageIds());
+        parkingManagement.reorderImages(displayOrderChangeReqDto.getIds());
     }
 
     @Transactional
-    public void deleteParkingMapImages(Long id, ParkingMapImageReqDto parkingMapImageReqDto) {
+    public void deleteParkingMapImages(Long id, DisplayOrderChangeReqDto displayOrderChangeReqDto) {
         ParkingManagement parkingManagement = parkingManagementRepository
                 .findByIdWithImages(id)
                 .orElseThrow(() -> new ParkingManagementNotFoundException(id));
-        parkingManagement.removeImages(parkingMapImageReqDto.getImageIds());
+        parkingManagement.removeImages(displayOrderChangeReqDto.getIds());
     }
 
     private ParkingManagement loadParkingManagementOrThrow(Long id) {

--- a/src/main/java/com/halo/eventer/domain/parking/service/ParkingNoticeService.java
+++ b/src/main/java/com/halo/eventer/domain/parking/service/ParkingNoticeService.java
@@ -1,0 +1,43 @@
+package com.halo.eventer.domain.parking.service;
+
+import com.halo.eventer.domain.parking.repository.ParkingNoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ParkingNoticeService {
+
+    private final ParkingNoticeRepository parkingNoticeRepository;
+
+    // 1. 주차 안내 등록
+    @Transactional
+    public void create(){
+
+    }
+
+    // 2. 주차 안내 리스트 조회
+    @Transactional(readOnly = true)
+    public void getParkingNotices(){
+
+    }
+    // 3. 주차 안내 제목, 내용 수정
+    @Transactional
+    public void updateParkingNoticeInfo(){
+
+    }
+
+    // 4. 주차 안내 visible 수정
+    @Transactional
+    public void updateParkingNoticeVisible(){
+
+    }
+
+    // 5. 주차 안내 삭제
+    @Transactional
+    public void delete(){
+
+    }
+
+}

--- a/src/main/java/com/halo/eventer/domain/parking/service/ParkingNoticeService.java
+++ b/src/main/java/com/halo/eventer/domain/parking/service/ParkingNoticeService.java
@@ -1,43 +1,82 @@
 package com.halo.eventer.domain.parking.service;
 
-import com.halo.eventer.domain.parking.repository.ParkingNoticeRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.parking.ParkingNotice;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeContentReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeResDto;
+import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
+import com.halo.eventer.domain.parking.exception.ParkingNoticeNotFoundException;
+import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
+import com.halo.eventer.domain.parking.repository.ParkingNoticeRepository;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ParkingNoticeService {
 
     private final ParkingNoticeRepository parkingNoticeRepository;
+    private final ParkingManagementRepository parkingManagementRepository;
 
-    // 1. 주차 안내 등록
     @Transactional
-    public void create(){
-
+    public void create(final long parkingManagementId, ParkingNoticeReqDto parkingNoticeReqDto) {
+        ParkingManagement parkingManagement = loadParkingManagementOrThrow(parkingManagementId);
+        ParkingNotice parkingNotice =
+                ParkingNotice.of(parkingNoticeReqDto.getTitle(), parkingNoticeReqDto.getContent(), parkingManagement);
+        parkingNoticeRepository.save(parkingNotice);
     }
 
-    // 2. 주차 안내 리스트 조회
     @Transactional(readOnly = true)
-    public void getParkingNotices(){
-
+    public List<ParkingNoticeResDto> getParkingNotices(final long parkingManagementId) {
+        return parkingNoticeRepository.findByIdParkingManagementId(parkingManagementId).stream()
+                .map(parkingNotice -> new ParkingNoticeResDto(
+                        parkingNotice.getId(),
+                        parkingNotice.getTitle(),
+                        parkingNotice.getContent(),
+                        parkingNotice.getVisible()))
+                .toList();
     }
-    // 3. 주차 안내 제목, 내용 수정
+
+    @Transactional(readOnly = true)
+    public List<ParkingNoticeResDto> getVisibleParkingNotices(final long parkingManagementId) {
+        return parkingNoticeRepository.findByIdParkingManagementIdAndVisible(parkingManagementId, true).stream()
+                .map(parkingNotice -> new ParkingNoticeResDto(
+                        parkingNotice.getId(),
+                        parkingNotice.getTitle(),
+                        parkingNotice.getContent(),
+                        parkingNotice.getVisible()))
+                .toList();
+    }
+
     @Transactional
-    public void updateParkingNoticeInfo(){
-
+    public void updateContent(final long id, ParkingNoticeContentReqDto parkingNoticeContentReqDto) {
+        ParkingNotice parkingNotice = loadParkingNoticeOrThrow(id);
+        parkingNotice.updateNotice(parkingNoticeContentReqDto.getTitle(), parkingNoticeContentReqDto.getContent());
     }
 
-    // 4. 주차 안내 visible 수정
     @Transactional
-    public void updateParkingNoticeVisible(){
-
+    public void changeVisibility(final long id, VisibilityChangeReqDto visibilityChangeReqDto) {
+        ParkingNotice parkingNotice = loadParkingNoticeOrThrow(id);
+        parkingNotice.changeVisible(visibilityChangeReqDto.getVisible());
     }
 
-    // 5. 주차 안내 삭제
     @Transactional
-    public void delete(){
-
+    public void delete(final long id) {
+        ParkingNotice parkingNotice = loadParkingNoticeOrThrow(id);
+        parkingNoticeRepository.delete(parkingNotice);
     }
 
+    private ParkingNotice loadParkingNoticeOrThrow(Long id) {
+        return parkingNoticeRepository.findById(id).orElseThrow(() -> new ParkingNoticeNotFoundException(id));
+    }
+
+    private ParkingManagement loadParkingManagementOrThrow(Long id) {
+        return parkingManagementRepository.findById(id).orElseThrow(() -> new ParkingManagementNotFoundException(id));
+    }
 }

--- a/src/main/java/com/halo/eventer/domain/parking/service/ParkingZoneService.java
+++ b/src/main/java/com/halo/eventer/domain/parking/service/ParkingZoneService.java
@@ -1,0 +1,116 @@
+package com.halo.eventer.domain.parking.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.parking.ParkingZone;
+import com.halo.eventer.domain.parking.dto.common.DisplayOrderChangeReqDto;
+import com.halo.eventer.domain.parking.dto.common.NameUpdateReqDto;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.ParkingLotSummaryDto;
+import com.halo.eventer.domain.parking.dto.parking_zone.ParkingZoneReqDto;
+import com.halo.eventer.domain.parking.dto.parking_zone.ParkingZoneResDto;
+import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
+import com.halo.eventer.domain.parking.exception.ParkingZoneNotFoundException;
+import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
+import com.halo.eventer.domain.parking.repository.ParkingZoneRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ParkingZoneService {
+
+    private final ParkingZoneRepository parkingZoneRepository;
+    private final ParkingManagementRepository parkingManagementRepository;
+
+    @Transactional
+    public void create(final long parkingManagementId, ParkingZoneReqDto parkingZoneReqDto) {
+        ParkingManagement parkingManagement = parkingManagementRepository
+                .findByIdWithParkingZone(parkingManagementId)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(parkingManagementId));
+        ParkingZone parkingZone =
+                ParkingZone.of(parkingZoneReqDto.getName(), parkingZoneReqDto.getVisible(), parkingManagement);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ParkingZoneResDto> getParkingZones(final long parkingManagementId) {
+        return parkingZoneRepository.findAllByParkingManagementId(parkingManagementId).stream()
+                .map(parkingZone -> new ParkingZoneResDto(
+                        parkingZone.getId(),
+                        parkingZone.getName(),
+                        parkingZone.getVisible(),
+                        parkingZone.getParkingLots().stream()
+                                .map(parkingLot -> new ParkingLotSummaryDto(
+                                        parkingLot.getId(),
+                                        parkingLot.getName(),
+                                        parkingLot.getCongestionLevel().toString(),
+                                        parkingLot.getVisible(),
+                                        parkingLot.getCopyAddress(),
+                                        parkingLot.getDisplayAddress()))
+                                .toList()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ParkingZoneResDto> getVisibleParkingZones(final long parkingManagementId) {
+        return parkingZoneRepository.findAllByParkingManagementIdAndVisible(parkingManagementId, true).stream()
+                .map(parkingZone -> new ParkingZoneResDto(
+                        parkingZone.getId(),
+                        parkingZone.getName(),
+                        parkingZone.getVisible(),
+                        parkingZone.getParkingLots().stream()
+                                .filter(parkingLot -> Boolean.TRUE.equals(parkingLot.getVisible()))
+                                .map(parkingLot -> new ParkingLotSummaryDto(
+                                        parkingLot.getId(),
+                                        parkingLot.getName(),
+                                        parkingLot.getCongestionLevel().toString(),
+                                        parkingLot.getVisible(),
+                                        parkingLot.getCopyAddress(),
+                                        parkingLot.getDisplayAddress()))
+                                .toList()))
+                .toList();
+    }
+
+    @Transactional
+    public void changeVisible(final long id, VisibilityChangeReqDto parkingZoneReqDto) {
+        ParkingZone parkingZone = loadParkingZoneOrThrow(id);
+        parkingZone.changeVisible(parkingZoneReqDto.getVisible());
+    }
+
+    @Transactional
+    public void changeName(final long id, NameUpdateReqDto nameUpdateReqDto) {
+        ParkingZone parkingZone = loadParkingZoneOrThrow(id);
+        parkingZone.updateName(nameUpdateReqDto.getName());
+    }
+
+    @Transactional
+    public void changeAllVisible(final long id, VisibilityChangeReqDto visibilityChangeReqDto) {
+        ParkingZone parkingZone = parkingZoneRepository
+                .findByIdWithParkingLot(id)
+                .orElseThrow(() -> new ParkingZoneNotFoundException(id));
+        parkingZone.changeAllVisible(visibilityChangeReqDto.getVisible());
+    }
+
+    @Transactional
+    public void changeDisplayOrder(final long parkingManagementId, DisplayOrderChangeReqDto displayOrderChangeReqDto) {
+        ParkingManagement parkingManagement = parkingManagementRepository
+                .findByIdWithParkingZone(parkingManagementId)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(parkingManagementId));
+        parkingManagement.reorderParkingZones(displayOrderChangeReqDto.getIds());
+    }
+
+    @Transactional
+    public void delete(final long parkingManagementId, final long id) {
+        ParkingManagement parkingManagement = parkingManagementRepository
+                .findByIdWithParkingZone(parkingManagementId)
+                .orElseThrow(() -> new ParkingManagementNotFoundException(parkingManagementId));
+        parkingManagement.removeParkingZone(id);
+    }
+
+    private ParkingZone loadParkingZoneOrThrow(Long id) {
+        return parkingZoneRepository.findById(id).orElseThrow(() -> new ParkingZoneNotFoundException(id));
+    }
+}

--- a/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
+++ b/src/main/java/com/halo/eventer/global/constants/SecurityConstants.java
@@ -55,7 +55,9 @@ public class SecurityConstants {
         "/test/festival",
         "/upload/preSigned",
         "/api/v2/admin/parking-managements/*/sub-page-info",
-        "/api/v2/common/parking-managements/*",
+        "/api/v2/user/parking-managements/*",
+        "/api/v2/user/parking-notices/*",
+        "/api/v2/user/parking-managements/*/parking-zones"
     };
 
     public static final String[] PUBLIC_POST_URLS = {

--- a/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingLotDoc.java
+++ b/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingLotDoc.java
@@ -1,0 +1,234 @@
+package com.halo.eventer.domain.parking.api_docs;
+
+import java.util.List;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.halo.eventer.global.constants.ApiConstraint;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+public class ParkingLotDoc {
+
+    private static final String TAG = "주차장";
+
+    public static RestDocumentationResultHandler create() {
+        return document(
+                "parking-lot 생성",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차장 생성")
+                        .description("특정 주차구역(parkingZoneId)에 주차장을 생성합니다. 주소같은 경우 네이버 API의 변수들 중 필요한 부분만 저장합니다.")
+                        .pathParameters(parameterWithName("parkingZoneId")
+                                .description("주차구역 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestSchema(Schema.schema("ParkingLotReqDto"))
+                        .requestFields(
+                                fieldWithPath("name")
+                                        .type(JsonFieldType.STRING)
+                                        .description("주차면 이름 (1~50자)")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(
+                                                        ApiConstraint.JavaxNotNull(), ApiConstraint.JavaxSize(1, 50)))),
+                                fieldWithPath("sido")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시/도")
+                                        .optional(),
+                                fieldWithPath("sigungu")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시/군/구")
+                                        .optional(),
+                                fieldWithPath("dongmyun")
+                                        .type(JsonFieldType.STRING)
+                                        .description("읍/면/동")
+                                        .optional(),
+                                fieldWithPath("roadName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("도로명")
+                                        .optional(),
+                                fieldWithPath("roadNumber")
+                                        .type(JsonFieldType.STRING)
+                                        .description("건물번호")
+                                        .optional(),
+                                fieldWithPath("buildingName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("상세주소/건물명")
+                                        .optional(),
+                                fieldWithPath("latitude")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("위도")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(ApiConstraint.JavaxNotNull()))),
+                                fieldWithPath("longitude")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("경도")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(ApiConstraint.JavaxNotNull()))))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler get() {
+        return document(
+                "parking-lot 단일 조회",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차장 단일 조회")
+                        .description("주차장 id로 상세 정보를 조회합니다. 백오피스에서 수정할 때 사용하는 용도입니다.")
+                        .responseSchema(Schema.schema("AdminParkingLotResDto"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차장 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("주차장 id"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("주차면 이름"),
+                                fieldWithPath("sido").type(JsonFieldType.STRING).description("시/도"),
+                                fieldWithPath("sigungu")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시/군/구"),
+                                fieldWithPath("dongmyun")
+                                        .type(JsonFieldType.STRING)
+                                        .description("읍/면/동"),
+                                fieldWithPath("roadName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("도로명"),
+                                fieldWithPath("roadNumber")
+                                        .type(JsonFieldType.STRING)
+                                        .description("건물번호"),
+                                fieldWithPath("buildingName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("상세주소/건물명"),
+                                fieldWithPath("latitude")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("위도"),
+                                fieldWithPath("longitude")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("경도"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler changeVisibility() {
+        return document(
+                "parking-lot 노출 순서 변경",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차장 노출 순서 변경")
+                        .description("주차장의 노출 여부를 변경합니다.")
+                        .requestSchema(Schema.schema("VisibilityChangeReqDto"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차장 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestFields(fieldWithPath("visible")
+                                .type(JsonFieldType.BOOLEAN)
+                                .description("노출 여부")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxNotNull()))))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler updateContent() {
+        return document(
+                "parking-lot 내용 수정",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차장 내용 수정")
+                        .description("주차장 정보를 수정합니다. visible 필드는 포함되지 않습니다.")
+                        .requestSchema(Schema.schema("ParkingLotReqDto"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차장 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestFields(
+                                fieldWithPath("name")
+                                        .type(JsonFieldType.STRING)
+                                        .description("주차장 이름 (1~50자)")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(
+                                                        ApiConstraint.JavaxNotNull(), ApiConstraint.JavaxSize(1, 50)))),
+                                fieldWithPath("sido")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시/도")
+                                        .optional(),
+                                fieldWithPath("sigungu")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시/군/구")
+                                        .optional(),
+                                fieldWithPath("dongmyun")
+                                        .type(JsonFieldType.STRING)
+                                        .description("읍/면/동")
+                                        .optional(),
+                                fieldWithPath("roadName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("도로명")
+                                        .optional(),
+                                fieldWithPath("roadNumber")
+                                        .type(JsonFieldType.STRING)
+                                        .description("건물번호")
+                                        .optional(),
+                                fieldWithPath("buildingName")
+                                        .type(JsonFieldType.STRING)
+                                        .description("상세주소/건물명")
+                                        .optional(),
+                                fieldWithPath("latitude")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("위도")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(ApiConstraint.JavaxNotNull()))),
+                                fieldWithPath("longitude")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("경도")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(ApiConstraint.JavaxNotNull()))))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler changeCongestionLevel() {
+        return document(
+                "parking-lot 혼잡도 변경",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차장 혼잡도 변경")
+                        .description("주차장의 혼잡도 레벨을 변경합니다. (예: LOW/MEDIUM/HIGH)")
+                        .requestSchema(Schema.schema("CongestionLevelReqDto"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차장 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestFields(fieldWithPath("congestionLevel")
+                                .type(JsonFieldType.STRING)
+                                .description("혼잡도 레벨 (LOW/MEDIUM/HIGH)")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxNotNull()))))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler delete() {
+        return document(
+                "parking-lot 삭제",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차장 삭제")
+                        .description("주차장 id로 주차장을 삭제합니다.")
+                        .pathParameters(parameterWithName("id")
+                                .description("주차장 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .build()));
+    }
+
+    /**
+     * 공통 에러 스니펫
+     */
+    public static RestDocumentationResultHandler errorSnippet(String identifier) {
+        return document(
+                identifier,
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .responseFields(
+                                fieldWithPath("code").description("에러 코드 번호"),
+                                fieldWithPath("message").description("상세 에러 메시지"),
+                                fieldWithPath("status").description("HTTP 상태 코드"))
+                        .build()));
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingNoticeDoc.java
+++ b/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingNoticeDoc.java
@@ -1,0 +1,170 @@
+package com.halo.eventer.domain.parking.api_docs;
+
+import java.util.List;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.halo.eventer.global.constants.ApiConstraint;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+public final class ParkingNoticeDoc {
+
+    private static final String TAG = "주차 공지/안내";
+
+    private ParkingNoticeDoc() {}
+
+    public static RestDocumentationResultHandler errorSnippet(String identifier) {
+        return document(
+                identifier,
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("에러 응답 형식")
+                        .responseFields(
+                                fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                                fieldWithPath("message")
+                                        .type(JsonFieldType.STRING)
+                                        .description("상세 메시지"),
+                                fieldWithPath("status")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("HTTP 상태 코드"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler create() {
+        return document(
+                "parking-notice-생성",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("공지 생성 (ADMIN)")
+                        .description("특정 주차관리(parkingManagementId)에 공지를 생성합니다.")
+                        .requestSchema(Schema.schema("ParkingNoticeReqDto"))
+                        .pathParameters(parameterWithName("parkingManagementId")
+                                .description("주차 관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                fieldWithPath("title")
+                                        .type(JsonFieldType.STRING)
+                                        .description("제목")
+                                        .attributes(key("constraints").value("필수, NotNull/NotBlank")),
+                                fieldWithPath("content")
+                                        .type(JsonFieldType.STRING)
+                                        .description("내용")
+                                        .attributes(key("constraints").value("필수, NotNull/NotBlank")))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler getAdminList() {
+        return document(
+                "parking-notice-관리자-목록조회",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("공지 목록 조회 (ADMIN)")
+                        .description("주차관리 ID에 연결된 전체 공지 목록을 조회합니다.")
+                        .pathParameters(parameterWithName("parkingManagementId")
+                                .description("주차관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
+                        .responseSchema(Schema.schema("ParkingNoticeResDto[]"))
+                        .responseFields(
+                                fieldWithPath("[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공지 ID"),
+                                fieldWithPath("[].title")
+                                        .type(JsonFieldType.STRING)
+                                        .description("제목"),
+                                fieldWithPath("[].content")
+                                        .type(JsonFieldType.STRING)
+                                        .description("내용"),
+                                fieldWithPath("[].visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler getUserVisibleList() {
+        return document(
+                "parking-notice-사용자-visible-조회",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("노출 공지 조회 (USER)")
+                        .description("사용자는 노출(visible = true)된 공지 목록만 조회합니다.")
+                        .pathParameters(parameterWithName("id")
+                                .description("주차관리 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .responseSchema(Schema.schema("ParkingNoticeResDto[]"))
+                        .responseFields(
+                                fieldWithPath("[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("공지 ID"),
+                                fieldWithPath("[].title")
+                                        .type(JsonFieldType.STRING)
+                                        .description("제목"),
+                                fieldWithPath("[].content")
+                                        .type(JsonFieldType.STRING)
+                                        .description("내용"),
+                                fieldWithPath("[].visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부(항상 true)"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler updateContent() {
+        return document(
+                "parking-notice-내용수정",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("공지 내용 수정 (ADMIN)")
+                        .description("공지의 제목/내용을 수정합니다.")
+                        .requestSchema(Schema.schema("ParkingNoticeContentReqDto"))
+                        .pathParameters(parameterWithName("id")
+                                .description("공지 ID")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(
+                                fieldWithPath("title")
+                                        .type(JsonFieldType.STRING)
+                                        .description("수정할 제목")
+                                        .attributes(key("constraints").value("필수, NotNull/NotBlank")),
+                                fieldWithPath("content")
+                                        .type(JsonFieldType.STRING)
+                                        .description("수정할 내용")
+                                        .attributes(key("constraints").value("필수, NotNull/NotBlank")))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler changeVisibility() {
+        return document(
+                "parking-notice-노출여부변경",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("공지 노출여부 변경 (ADMIN)")
+                        .description("공지의 visible 값을 변경합니다.")
+                        .requestSchema(Schema.schema("ParkingNoticeVisibilityReqDto"))
+                        .pathParameters(parameterWithName("id").description("공지 ID (1 이상)"))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
+                        .requestFields(fieldWithPath("visible")
+                                .type(JsonFieldType.BOOLEAN)
+                                .description("변경할 노출 여부, (NotNull)"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler deleteNotice() {
+        return document(
+                "parking-notice-삭제",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("공지 삭제 (ADMIN)")
+                        .description("공지 한 건을 삭제합니다.")
+                        .pathParameters(parameterWithName("id").description("공지 ID (1 이상)"))
+                        .requestHeaders(headerWithName("Authorization").description("Bearer {JWT}"))
+                        .build()));
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingZoneDoc.java
+++ b/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingZoneDoc.java
@@ -1,0 +1,232 @@
+package com.halo.eventer.domain.parking.api_docs;
+
+import java.util.List;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.halo.eventer.global.constants.ApiConstraint;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+public class ParkingZoneDoc {
+
+    private static final String TAG = "주차구역";
+
+    public static RestDocumentationResultHandler create() {
+        return document(
+                "parking-zone 생성",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차구역 생성")
+                        .description(
+                                "특정 주차관리(parkingManagementId)에 주차구역을 생성합니다. 피그마 상에 노출여부도 생성할 때 결정할 수 있어 주차장 지도와는 다르게 visible이 추가되었습니다.")
+                        .pathParameters(parameterWithName("parkingManagementId")
+                                .description("주차관리 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestSchema(Schema.schema("ParkingZoneReqDto"))
+                        .requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("주차구역 이름 (1~50자)"),
+                                fieldWithPath("visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부 (NotNull)"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler getAdminList() {
+        return document(
+                "parking-zone 리스트 조회(ADMIN)",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차구역 리스트 조회(관리자)")
+                        .description(
+                                "주차관리 id 기준으로 전체 주차구역 목록을 조회합니다. 구역 및 주차장 리스트 페이지, 주차장 혼잡도 페이지에서 모두 이 API 하나만 사용 (관리자용)")
+                        .responseSchema(Schema.schema("ParkingZoneResDtoList"))
+                        .pathParameters(parameterWithName("parkingManagementId")
+                                .description("주차관리 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .responseFields(
+                                fieldWithPath("[]").description("주차구역 목록"),
+                                fieldWithPath("[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("주차구역 id"),
+                                fieldWithPath("[].name")
+                                        .type(JsonFieldType.STRING)
+                                        .description("주차구역 이름"),
+                                fieldWithPath("[].visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부"),
+                                fieldWithPath("[].parkingLots[]")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("주차면 요약 목록"),
+                                fieldWithPath("[].parkingLots[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("주차면 id"),
+                                fieldWithPath("[].parkingLots[].name")
+                                        .type(JsonFieldType.STRING)
+                                        .description("주차면 이름"),
+                                fieldWithPath("[].parkingLots[].congestionLevel")
+                                        .type(JsonFieldType.STRING)
+                                        .description("혼잡도 레벨"),
+                                fieldWithPath("[].parkingLots[].visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부"),
+                                fieldWithPath("[].parkingLots[].copyAddress")
+                                        .type(JsonFieldType.STRING)
+                                        .description("복사용 주소"),
+                                fieldWithPath("[].parkingLots[].displayAddress")
+                                        .type(JsonFieldType.STRING)
+                                        .description("노출용 주소"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler getUserList() {
+        return document(
+                "parking-zone 리스트 조회(USER 공개)",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차구역 공개 리스트 조회(사용자)")
+                        .description(
+                                "주차관리 id 기준으로 공개 상태의 주차구역 목록을 조회합니다. (사용자용) 주차 구역 visible = false일 경우 그 하위 주차장 모두 조회 불가")
+                        .responseSchema(Schema.schema("ParkingZoneResDtoList"))
+                        .pathParameters(parameterWithName("parkingManagementId")
+                                .description("주차관리 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .responseFields(
+                                fieldWithPath("[]").description("공개 주차구역 목록"),
+                                fieldWithPath("[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("주차구역 id"),
+                                fieldWithPath("[].name")
+                                        .type(JsonFieldType.STRING)
+                                        .description("주차구역 이름"),
+                                fieldWithPath("[].visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부"),
+                                fieldWithPath("[].parkingLots[]")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("주차면 요약 목록"),
+                                fieldWithPath("[].parkingLots[].id")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("주차면 id"),
+                                fieldWithPath("[].parkingLots[].name")
+                                        .type(JsonFieldType.STRING)
+                                        .description("주차면 이름"),
+                                fieldWithPath("[].parkingLots[].congestionLevel")
+                                        .type(JsonFieldType.STRING)
+                                        .description("혼잡도 레벨"),
+                                fieldWithPath("[].parkingLots[].visible")
+                                        .type(JsonFieldType.BOOLEAN)
+                                        .description("노출 여부"),
+                                fieldWithPath("[].parkingLots[].copyAddress")
+                                        .type(JsonFieldType.STRING)
+                                        .description("복사용 주소"),
+                                fieldWithPath("[].parkingLots[].displayAddress")
+                                        .type(JsonFieldType.STRING)
+                                        .description("노출용 주소"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler changeVisibility() {
+        return document(
+                "parking-zone 노출 여부 변경",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차구역 노출 여부 변경")
+                        .description("주차구역의 노출 여부를 변경합니다.")
+                        .requestSchema(Schema.schema("VisibilityChangeReqDto"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차구역 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestFields(fieldWithPath("visible")
+                                .type(JsonFieldType.BOOLEAN)
+                                .description("노출 여부")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxNotNull()))))
+                        .build()));
+    }
+
+    /**
+     * PATCH /api/v2/admin/parking-zones/{id}/name
+     * 이름 변경
+     */
+    public static RestDocumentationResultHandler rename() {
+        return document(
+                "parking-zone 이름 변경",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차구역 이름 변경")
+                        .description("주차구역 이름을 변경합니다.")
+                        .requestSchema(Schema.schema("NameUpdateReqDto"))
+                        .pathParameters(parameterWithName("id")
+                                .description("주차구역 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestFields(fieldWithPath("name")
+                                .type(JsonFieldType.STRING)
+                                .description("변경할 이름 (1~50자)")
+                                .attributes(key("validationConstraints")
+                                        .value(List.of(ApiConstraint.JavaxNotEmpty(), ApiConstraint.JavaxSize(1, 50)))))
+                        .build()));
+    }
+
+    /**
+     * PATCH /api/v2/admin/parking-managements/{parkingManagementId}/parking-zones/display-order
+     * 표시 순서 변경
+     */
+    public static RestDocumentationResultHandler changeDisplayOrder() {
+        return document(
+                "parking-zone 표시순서 변경",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차구역 표시 순서 변경")
+                        .description("주차구역의 표시 순서를 일괄 변경합니다. 주차장 지도 순서 변경 로직과 동일하게 동작합니다.")
+                        .requestSchema(Schema.schema("DisplayOrderChangeReqDto"))
+                        .pathParameters(parameterWithName("parkingManagementId")
+                                .description("주차관리 id")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .requestFields(fieldWithPath("ids[]")
+                                .type(JsonFieldType.ARRAY)
+                                .description("표시 순서에 맞춘 주차구역 id 목록 (선두가 가장 먼저 표시)")
+                                .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxNotEmpty()))))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler delete() {
+        return document(
+                "parking-zone 삭제",
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .summary("주차구역 삭제")
+                        .description("주차구역 id로 주차구역을 삭제합니다.")
+                        .pathParameters(
+                                parameterWithName("id")
+                                        .description("주차구역 id")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(ApiConstraint.JavaxMin2(1)))),
+                                parameterWithName("parkingManagementId")
+                                        .description("주차 관리 시스템 id")
+                                        .attributes(key("validationConstraints")
+                                                .value(List.of(ApiConstraint.JavaxMin2(1)))))
+                        .build()));
+    }
+
+    /**
+     * 공통 에러 스니펫
+     */
+    public static RestDocumentationResultHandler errorSnippet(String identifier) {
+        return document(
+                identifier,
+                resource(ResourceSnippetParameters.builder()
+                        .tag(TAG)
+                        .responseFields(
+                                fieldWithPath("code").description("에러 코드 번호"),
+                                fieldWithPath("message").description("상세 에러 메시지"),
+                                fieldWithPath("status").description("HTTP 상태 코드"))
+                        .build()));
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/controller/ParkingLotControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/controller/ParkingLotControllerTest.java
@@ -1,0 +1,266 @@
+package com.halo.eventer.domain.parking.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.parking.api_docs.ParkingLotDoc;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.AdminParkingLotResDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.CongestionLevelReqDto;
+import com.halo.eventer.domain.parking.dto.parking_lot.ParkingLotReqDto;
+import com.halo.eventer.domain.parking.service.ParkingLotService;
+import com.halo.eventer.global.config.ControllerTestSecurityBeans;
+import com.halo.eventer.global.config.security.SecurityConfig;
+import com.halo.eventer.global.security.provider.JwtProvider;
+
+import static com.halo.eventer.global.common.ApiErrorAssert.assertError;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ParkingLotController.class)
+@AutoConfigureRestDocs
+@SuppressWarnings("NonAsciiCharacters")
+@ActiveProfiles("test")
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
+public class ParkingLotControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ParkingLotService parkingLotService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    private ParkingLotReqDto createReq;
+    private ParkingLotReqDto updateReq;
+    private AdminParkingLotResDto adminRes;
+    private VisibilityChangeReqDto visibleOnReq;
+    private CongestionLevelReqDto congestionReq;
+
+    @BeforeEach
+    void setUp() {
+        createReq = new ParkingLotReqDto("제1주차장", "서울특별시", "강남구", "역삼동", "테헤란로", "427", "멀티캠퍼스", 37.501, 127.036);
+
+        updateReq = new ParkingLotReqDto("제1주차장(수정)", "서울특별시", "강남구", "역삼동", "테헤란로", "427", "멀티캠퍼스", 37.502, 127.037);
+
+        adminRes =
+                new AdminParkingLotResDto(1L, "제1주차장", "서울특별시", "강남구", "역삼동", "테헤란로", "427", "멀티캠퍼스", 37.501, 127.036);
+
+        visibleOnReq = new VisibilityChangeReqDto(true);
+
+        congestionReq = new CongestionLevelReqDto("HIGH");
+    }
+
+    // ----------------------------------------
+    // 생성
+    // ----------------------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_생성_성공() throws Exception {
+        // given
+        doNothing().when(parkingLotService).create(eq(10L), any(ParkingLotReqDto.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v2/admin/parking-zones/{parkingZoneId}/parking-lots", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createReq)))
+                .andExpect(status().isOk())
+                .andDo(ParkingLotDoc.create());
+    }
+
+    @Test
+    void 주차면_생성_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(post("/api/v2/admin/parking-zones/{parkingZoneId}/parking-lots", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createReq)))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingLotDoc.errorSnippet("주차_생성_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // ----------------------------------------
+    // 단일 조회
+    // ----------------------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_단일조회_성공() throws Exception {
+        // given
+        given(parkingLotService.getParkingLot(1L)).willReturn(adminRes);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/admin/parking-lots/{id}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(adminRes)))
+                .andDo(ParkingLotDoc.get());
+    }
+
+    @Test
+    void 주차면_단일조회_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(get("/api/v2/admin/parking-lots/{id}", 1L))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingLotDoc.errorSnippet("주차_조회_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // ----------------------------------------
+    // 가시성 변경
+    // ----------------------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_가시성_변경_성공() throws Exception {
+        // given
+        doNothing().when(parkingLotService).changeVisible(eq(1L), any(VisibilityChangeReqDto.class));
+
+        // when & then
+        mockMvc.perform(patch("/api/v2/admin/parking-lots/{id}/visibility", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(visibleOnReq)))
+                .andExpect(status().isOk())
+                .andDo(ParkingLotDoc.changeVisibility());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_가시성_변경시_visible_null_검증실패() throws Exception {
+        // given
+        VisibilityChangeReqDto bad = new VisibilityChangeReqDto(null);
+
+        // when & then
+        ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-lots/{id}/visibility", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(bad)))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingLotDoc.errorSnippet("주차_가시성_변경_검증실패_visible_null"));
+        // 프로젝트 규칙에 맞춘 에러 코드/메시지
+        assertError(result, "C013", "must not be null", 400);
+    }
+
+    @Test
+    void 주차면_가시성_변경_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-lots/{id}/visibility", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(visibleOnReq)))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingLotDoc.errorSnippet("주차_가시성_변경_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // ----------------------------------------
+    // 내용 수정
+    // ----------------------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_내용_수정_성공() throws Exception {
+        // given
+        doNothing().when(parkingLotService).updateContent(eq(1L), any(ParkingLotReqDto.class));
+
+        // when & then
+        mockMvc.perform(put("/api/v2/admin/parking-lots/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateReq)))
+                .andExpect(status().isOk())
+                .andDo(ParkingLotDoc.updateContent());
+    }
+
+    @Test
+    void 주차면_내용_수정_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(put("/api/v2/admin/parking-lots/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateReq)))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingLotDoc.errorSnippet("주차_내용_수정_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // ----------------------------------------
+    // 혼잡도 변경
+    // ----------------------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_혼잡도_변경_성공() throws Exception {
+        // given
+        doNothing().when(parkingLotService).changeCongestionLevel(eq(1L), any(CongestionLevelReqDto.class));
+
+        // when & then
+        mockMvc.perform(patch("/api/v2/admin/parking-lots/{id}/congestion-level", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(congestionReq)))
+                .andExpect(status().isOk())
+                .andDo(ParkingLotDoc.changeCongestionLevel());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_혼잡도_변경시_레벨_null_검증실패() throws Exception {
+        // given
+        CongestionLevelReqDto bad = new CongestionLevelReqDto(null);
+
+        // when & then
+        ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-lots/{id}/congestion-level", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(bad)))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingLotDoc.errorSnippet("주차_혼잡도_변경_검증실패_level_null"));
+        // 프로젝트 규칙에 맞춘 에러 코드/메시지
+        assertError(result, "C013", "must not be null", 400);
+    }
+
+    @Test
+    void 주차면_혼잡도_변경_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-lots/{id}/congestion-level", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(congestionReq)))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingLotDoc.errorSnippet("주차_혼잡도_변경_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // ----------------------------------------
+    // 삭제
+    // ----------------------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차면_삭제_성공() throws Exception {
+        // given
+        doNothing().when(parkingLotService).delete(1L);
+
+        // when & then
+        mockMvc.perform(delete("/api/v2/admin/parking-lots/{id}", 1L))
+                .andExpect(status().isOk())
+                .andDo(ParkingLotDoc.delete());
+        verify(parkingLotService, times(1)).delete(1L);
+    }
+
+    @Test
+    void 주차_삭제_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(delete("/api/v2/admin/parking-lots/{id}", 1L))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingLotDoc.errorSnippet("주차_삭제_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/controller/ParkingNoticeControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/controller/ParkingNoticeControllerTest.java
@@ -1,0 +1,309 @@
+package com.halo.eventer.domain.parking.controller;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.parking.api_docs.ParkingNoticeDoc;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeContentReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeResDto;
+import com.halo.eventer.domain.parking.service.ParkingNoticeService;
+import com.halo.eventer.global.config.ControllerTestSecurityBeans;
+import com.halo.eventer.global.config.security.SecurityConfig;
+import com.halo.eventer.global.security.provider.JwtProvider;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ParkingNoticeController.class)
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
+class ParkingNoticeControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    ParkingNoticeService parkingNoticeService;
+
+    @MockitoBean
+    JwtProvider jwtProvider;
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 관리자_공지_생성_성공() throws Exception {
+        // given
+        Long parkingManagementId = 1L;
+        ParkingNoticeReqDto dto = new ParkingNoticeReqDto("제목", "내용");
+
+        // when // then
+        mockMvc.perform(post(
+                                "/api/v2/admin/parking-managements/{parkingManagementId}/parking-notices",
+                                parkingManagementId)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andDo(ParkingNoticeDoc.create());
+
+        verify(parkingNoticeService).create(eq(parkingManagementId), any(ParkingNoticeReqDto.class));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 관리자_공지_생성_실패_title_null_검증에러() throws Exception {
+        Long parkingManagementId = 1L;
+        String body = """
+                {"title":null,"content":"내용","visible":true}
+                """;
+
+        mockMvc.perform(post(
+                                "/api/v2/admin/parking-managements/{parkingManagementId}/parking-notices",
+                                parkingManagementId)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingNoticeDoc.errorSnippet("관리자 공지 생성시 title null 불가"));
+
+        verify(parkingNoticeService, never()).create(anyLong(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 관리자_공지_목록조회_성공() throws Exception {
+        Long parkingManagementId = 1L;
+        List<ParkingNoticeResDto> list = List.of(
+                new ParkingNoticeResDto(10L, "t1", "c1", true), new ParkingNoticeResDto(20L, "t2", "c2", false));
+        when(parkingNoticeService.getParkingNotices(parkingManagementId)).thenReturn(list);
+
+        mockMvc.perform(get(
+                                "/api/v2/admin/parking-managements/{parkingManagementId}/parking-notices",
+                                parkingManagementId)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(10))
+                .andExpect(jsonPath("$[0].title").value("t1"))
+                .andExpect(jsonPath("$[0].content").value("c1"))
+                .andExpect(jsonPath("$[0].visible").value(true))
+                .andExpect(jsonPath("$[1].id").value(20))
+                .andExpect(jsonPath("$[1].visible").value(false))
+                .andDo(ParkingNoticeDoc.getAdminList());
+
+        verify(parkingNoticeService).getParkingNotices(parkingManagementId);
+    }
+
+    @Test
+    void 사용자_visible_공지_조회_성공() throws Exception {
+        Long id = 7L;
+        List<ParkingNoticeResDto> list = List.of(new ParkingNoticeResDto(1L, "알림", "본문", true));
+        when(parkingNoticeService.getVisibleParkingNotices(id)).thenReturn(list);
+
+        mockMvc.perform(get("/api/v2/user/parking-notices/{id}", id).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].visible").value(true))
+                .andDo(ParkingNoticeDoc.getUserVisibleList());
+
+        verify(parkingNoticeService).getVisibleParkingNotices(id);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 공지_내용수정_성공() throws Exception {
+        Long id = 11L;
+        ParkingNoticeContentReqDto dto = new ParkingNoticeContentReqDto("수정제목", "수정내용");
+
+        mockMvc.perform(patch("/api/v2/admin/parking-notices/{id}/content", id)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andDo(ParkingNoticeDoc.updateContent());
+
+        verify(parkingNoticeService).updateContent(eq(id), any(ParkingNoticeContentReqDto.class));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 공지_내용수정_실패_title_null_검증에러() throws Exception {
+        Long id = 11L;
+        String body = """
+                {"title":null,"content":"수정내용"}
+                """;
+
+        mockMvc.perform(patch("/api/v2/admin/parking-notices/{id}/content", id)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingNoticeDoc.errorSnippet("공지 내용 수정시 title null 불가"));
+
+        verify(parkingNoticeService, never()).updateContent(anyLong(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 공지_노출여부_변경_성공() throws Exception {
+        Long id = 100L;
+        VisibilityChangeReqDto dto = new VisibilityChangeReqDto(false);
+
+        mockMvc.perform(patch("/api/v2/admin/parking-notices/{id}/visibility", id)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andDo(ParkingNoticeDoc.changeVisibility());
+
+        verify(parkingNoticeService).changeVisibility(eq(id), any(VisibilityChangeReqDto.class));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 공지_노출여부_변경_실패_visible_null_검증에러() throws Exception {
+        Long id = 100L;
+        String body = """
+                {"visible":null}
+                """;
+
+        mockMvc.perform(patch("/api/v2/admin/parking-notices/{id}/visibility", id)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingNoticeDoc.errorSnippet("공지 노출 여부 null 불가"));
+
+        verify(parkingNoticeService, never()).changeVisibility(anyLong(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 공지_삭제_성공() throws Exception {
+        Long id = 55L;
+
+        mockMvc.perform(delete("/api/v2/admin/parking-notices/{id}", id)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(ParkingNoticeDoc.deleteNotice());
+
+        verify(parkingNoticeService).delete(id);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 경로변수_검증_실패_parkingManagementId_0이면() throws Exception {
+        mockMvc.perform(get("/api/v2/admin/parking-managements/{parkingManagementId}/parking-notices", 0L)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingNoticeDoc.errorSnippet("어드민 조회시 id 1 미만 오류"));
+        ;
+
+        verify(parkingNoticeService, never()).getParkingNotices(anyLong());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 경로변수_검증_실패_id_0이면() throws Exception {
+        mockMvc.perform(delete("/api/v2/admin/parking-notices/{id}", 0L)
+                        .header("Authorization", "Bearer test-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        verify(parkingNoticeService, never()).delete(anyLong());
+    }
+
+    @Test
+    void 관리자_공지_생성_인증없음_401() throws Exception {
+        Long parkingManagementId = 1L;
+        String body = """
+                {"title":"t","content":"c","visible":true}
+                """;
+
+        mockMvc.perform(post(
+                                "/api/v2/admin/parking-managements/{parkingManagementId}/parking-notices",
+                                parkingManagementId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingNoticeDoc.errorSnippet("주차장 공지 생성 인증 거부"));
+
+        verify(parkingNoticeService, never()).create(anyLong(), any());
+    }
+
+    @Test
+    void 관리자_공지_목록조회_인증없음_401() throws Exception {
+        mockMvc.perform(get("/api/v2/admin/parking-managements/{parkingManagementId}/parking-notices", 1L))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingNoticeDoc.errorSnippet("어드민용 주차장 공지 목록 조회 인증 거부"));
+
+        verify(parkingNoticeService, never()).getParkingNotices(anyLong());
+    }
+
+    @Test
+    void 공지_내용수정_인증없음_401() throws Exception {
+        Long id = 11L;
+        String body = """
+                {"title":"t","content":"c"}
+                """;
+
+        mockMvc.perform(patch("/api/v2/admin/parking-notices/{id}/content", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingNoticeDoc.errorSnippet("주차장 공지 내용 수정 인증거부"));
+        verify(parkingNoticeService, never()).updateContent(anyLong(), any());
+    }
+
+    @Test
+    void 공지_노출여부_변경_인증없음_401() throws Exception {
+        Long id = 100L;
+        String body = """
+                {"visible":false}
+                """;
+
+        mockMvc.perform(patch("/api/v2/admin/parking-notices/{id}/visibility", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingNoticeDoc.errorSnippet("주차장 공지 visible 변경 인증 거부"));
+
+        verify(parkingNoticeService, never()).changeVisibility(anyLong(), any());
+    }
+
+    @Test
+    void 공지_삭제_인증없음_401() throws Exception {
+        mockMvc.perform(delete("/api/v2/admin/parking-notices/{id}", 55L))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingNoticeDoc.errorSnippet("주차장 공지 삭제 인증 거부"));
+
+        verify(parkingNoticeService, never()).delete(anyLong());
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/controller/ParkingZoneControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/controller/ParkingZoneControllerTest.java
@@ -1,0 +1,377 @@
+package com.halo.eventer.domain.parking.controller;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.halo.eventer.domain.parking.api_docs.ParkingZoneDoc;
+import com.halo.eventer.domain.parking.dto.common.DisplayOrderChangeReqDto;
+import com.halo.eventer.domain.parking.dto.common.NameUpdateReqDto;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_zone.ParkingZoneReqDto;
+import com.halo.eventer.domain.parking.dto.parking_zone.ParkingZoneResDto;
+import com.halo.eventer.domain.parking.service.ParkingZoneService;
+import com.halo.eventer.global.config.ControllerTestSecurityBeans;
+import com.halo.eventer.global.config.security.SecurityConfig;
+import com.halo.eventer.global.security.provider.JwtProvider;
+
+import static com.halo.eventer.global.common.ApiErrorAssert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ParkingZoneController.class)
+@AutoConfigureRestDocs
+@SuppressWarnings("NonAsciiCharacters")
+@ActiveProfiles("test")
+@Import({ControllerTestSecurityBeans.class, SecurityConfig.class})
+public class ParkingZoneControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ParkingZoneService parkingZoneService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    private ParkingZoneReqDto createReq;
+    private ParkingZoneResDto zone1;
+    private ParkingZoneResDto zone2;
+
+    private VisibilityChangeReqDto visibilityOnReq;
+    private NameUpdateReqDto renameReq;
+    private DisplayOrderChangeReqDto displayOrderReq;
+
+    @BeforeEach
+    void setUp() {
+        createReq = new ParkingZoneReqDto();
+        // @NoArgsConstructor + 필드 접근자만 있으므로, 직렬화 테스트 편의상 JSON 문자열로 바인딩할 예정
+
+        visibilityOnReq = new VisibilityChangeReqDto(true);
+        renameReq = new NameUpdateReqDto();
+        displayOrderReq = new DisplayOrderChangeReqDto();
+
+        // 응답 DTO fixture
+        var lot1 = new com.halo.eventer.domain.parking.dto.parking_lot.ParkingLotSummaryDto(
+                100L, "A구역 1번", "LOW", true, "서울 강남구...", "강남구 ...");
+        var lot2 = new com.halo.eventer.domain.parking.dto.parking_lot.ParkingLotSummaryDto(
+                101L, "A구역 2번", "HIGH", true, "서울 강남구...", "강남구 ...");
+
+        zone1 = new ParkingZoneResDto(1L, "A구역", true, List.of(lot1, lot2));
+        zone2 = new ParkingZoneResDto(2L, "B구역", false, List.of());
+    }
+
+    // -----------------------------
+    // 생성
+    // -----------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_생성_성공() throws Exception {
+        // given
+        doNothing().when(parkingZoneService).create(eq(10L), any(ParkingZoneReqDto.class));
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "name": "A구역", "visible": true }
+                                """))
+                .andExpect(status().isOk())
+                .andDo(ParkingZoneDoc.create());
+    }
+
+    @Test
+    void 주차구역_생성_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        post("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "name": "A구역", "visible": true }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_생성_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_생성시_name_빈값이면_400() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        post("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "name": "", "visible": true }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_생성_name_NotEmpty"));
+        assertError(result, "C013", "must not be empty", 400);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_생성시_visible_null이면_400() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        post("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "name": "A구역", "visible": null }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_생성_visible_NotNull"));
+        assertError(result, "C013", "must not be null", 400);
+    }
+
+    // -----------------------------
+    // 관리자용 목록 조회
+    // -----------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_목록_조회_성공_ADMIN() throws Exception {
+        // given
+        given(parkingZoneService.getParkingZones(10L)).willReturn(List.of(zone1, zone2));
+
+        // when & then
+        mockMvc.perform(get("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones", 10L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(zone1.getId()))
+                .andExpect(jsonPath("$[0].name").value(zone1.getName()))
+                .andExpect(jsonPath("$[0].visible").value(zone1.getVisible()))
+                .andExpect(jsonPath("$[0].parkingLots.length()")
+                        .value(zone1.getParkingLots().size()))
+                .andDo(ParkingZoneDoc.getAdminList());
+    }
+
+    @Test
+    void 주차구역_목록_조회_인증거부_ADMIN() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        get("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones", 10L))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_목록_ADMIN_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // -----------------------------
+    // 사용자용 목록 조회(공개)
+    // -----------------------------
+    @Test
+    void 주차구역_목록_조회_USER_공개목록() throws Exception {
+        // given
+        given(parkingZoneService.getVisibleParkingZones(10L)).willReturn(List.of(zone1));
+
+        // when & then
+        mockMvc.perform(get("/api/v2/user/parking-managements/{parkingManagementId}/parking-zones", 10L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(zone1.getId()))
+                .andExpect(jsonPath("$[0].visible").value(true))
+                .andDo(ParkingZoneDoc.getUserList());
+    }
+
+    // -----------------------------
+    // 가시성 변경
+    // -----------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_가시성_변경_성공() throws Exception {
+        doNothing().when(parkingZoneService).changeVisible(eq(1L), any(VisibilityChangeReqDto.class));
+
+        mockMvc.perform(
+                        patch("/api/v2/admin/parking-zones/{id}/visibility", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "visible": true }
+                                """))
+                .andExpect(status().isOk())
+                .andDo(ParkingZoneDoc.changeVisibility());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_가시성_변경시_visible_null이면_400() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        patch("/api/v2/admin/parking-zones/{id}/visibility", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "visible": null }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_가시성_변경_visible_NotNull"));
+        assertError(result, "C013", "must not be null", 400);
+    }
+
+    @Test
+    void 주차구역_가시성_변경_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        patch("/api/v2/admin/parking-zones/{id}/visibility", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "visible": true }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_가시성_변경_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // -----------------------------
+    // 이름 변경
+    // -----------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_이름_변경_성공() throws Exception {
+        doNothing().when(parkingZoneService).changeName(eq(1L), any(NameUpdateReqDto.class));
+
+        mockMvc.perform(
+                        patch("/api/v2/admin/parking-zones/{id}/name", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "name": "B구역" }
+                                """))
+                .andExpect(status().isOk())
+                .andDo(ParkingZoneDoc.rename());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_이름_변경시_name_빈값이면_400() throws Exception {
+        ResultActions result = mockMvc.perform(patch("/api/v2/admin/parking-zones/{id}/name", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                                """
+                                { "name": "" }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_이름_변경_name_NotEmpty"));
+        assertError(result, "C013", "must not be empty", 400);
+    }
+
+    @Test
+    void 주차구역_이름_변경_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        patch("/api/v2/admin/parking-zones/{id}/name", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "name": "B구역" }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_이름_변경_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // -----------------------------
+    // 표시 순서 변경
+    // -----------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_표시순서_변경_성공() throws Exception {
+        doNothing().when(parkingZoneService).changeDisplayOrder(eq(10L), any(DisplayOrderChangeReqDto.class));
+
+        mockMvc.perform(
+                        put("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones/display-order", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "ids": [2,1,3] }
+                                """))
+                .andExpect(status().isOk())
+                .andDo(ParkingZoneDoc.changeDisplayOrder());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_표시순서_변경시_ids_null이면_400() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        put("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones/display-order", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "ids": null }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_표시순서_ids_NotNull"));
+        assertError(result, "C013", "must not be null", 400);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_표시순서_변경시_ids에_0_포함되면_400() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        put("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones/display-order", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "ids": [1,0,3] }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_표시순서_ids_Min"));
+        assertError(result, "C013", "must be greater than or equal to 1", 400);
+    }
+
+    @Test
+    void 주차구역_표시순서_변경_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        put("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones/display-order", 10L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                { "ids": [2,1,3] }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_표시순서_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+
+    // -----------------------------
+    // 삭제
+    // -----------------------------
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void 주차구역_삭제_성공() throws Exception {
+        doNothing().when(parkingZoneService).delete(10L, 1L);
+
+        mockMvc.perform(delete("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones/{id}", 10L, 1L))
+                .andExpect(status().isOk())
+                .andDo(ParkingZoneDoc.delete());
+        verify(parkingZoneService, times(1)).delete(10L, 1L);
+    }
+
+    @Test
+    void 주차구역_삭제_인증거부() throws Exception {
+        ResultActions result = mockMvc.perform(
+                        delete("/api/v2/admin/parking-managements/{parkingManagementId}/parking-zones/{id}", 10L, 1L))
+                .andExpect(status().isUnauthorized())
+                .andDo(ParkingZoneDoc.errorSnippet("주차구역_삭제_인증_거부"));
+        assertError(result, "A002", "Unauthenticated", 401);
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/entity/ParkingNoticeTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/entity/ParkingNoticeTest.java
@@ -1,0 +1,92 @@
+package com.halo.eventer.domain.parking.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.halo.eventer.domain.festival.Festival;
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.parking.ParkingNotice;
+
+import static com.halo.eventer.domain.festival.FestivalFixture.축제_엔티티;
+import static org.assertj.core.api.Assertions.*;
+
+@SuppressWarnings("NonAsciiCharacters")
+class ParkingNoticeTest {
+
+    private Festival 축제;
+    private ParkingManagement 주차관리;
+
+    @BeforeEach
+    void setUp() {
+        축제 = 축제_엔티티();
+        주차관리 = ParkingManagement.of(축제, "주차 안내", null, "메인 제목", "설명", "자세히 보기", "https://example.com", "bg.jpg", true);
+    }
+
+    @Test
+    void 정적팩토리_of_생성시_양방향_연결과_필드가_설정된다() {
+        // given
+        String title = "공지 제목";
+        String content = "공지 내용";
+        Boolean visible = true;
+
+        // when
+        ParkingNotice notice = ParkingNotice.of(title, content, 주차관리);
+
+        // then
+        assertThat(notice.getParkingManagement()).isEqualTo(주차관리);
+        assertThat(주차관리.getParkingNotices()).contains(notice);
+
+        assertThat(notice.getTitle()).isEqualTo(title);
+        assertThat(notice.getContent()).isEqualTo(content);
+        assertThat(notice.getVisible()).isTrue();
+    }
+
+    @Test
+    void updateNotice_호출시_제목과_내용이_갱신된다() {
+        // given
+        ParkingNotice notice = ParkingNotice.of("초기 제목", "초기 내용", 주차관리);
+
+        // when
+        notice.updateNotice("변경 제목", "변경 내용");
+
+        // then
+        assertThat(notice.getTitle()).isEqualTo("변경 제목");
+        assertThat(notice.getContent()).isEqualTo("변경 내용");
+        // 가시성/연결은 변경되지 않음
+        assertThat(notice.getVisible()).isTrue();
+        assertThat(notice.getParkingManagement()).isEqualTo(주차관리);
+    }
+
+    @Nested
+    class 가시성_변경 {
+
+        ParkingNotice notice;
+
+        @BeforeEach
+        void init() {
+            notice = ParkingNotice.of("제목", "내용", 주차관리);
+        }
+
+        @Test
+        void changeVisible_true에서_false로_변경된다() {
+            // when
+            notice.changeVisible(false);
+
+            // then
+            assertThat(notice.getVisible()).isFalse();
+        }
+
+        @Test
+        void changeVisible_false에서_true로_변경된다() {
+            // given
+            notice.changeVisible(false);
+
+            // when
+            notice.changeVisible(true);
+
+            // then
+            assertThat(notice.getVisible()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/halo/eventer/domain/parking/service/ParkingManagementServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/service/ParkingManagementServiceTest.java
@@ -17,11 +17,11 @@ import com.halo.eventer.domain.festival.exception.FestivalNotFoundException;
 import com.halo.eventer.domain.festival.repository.FestivalRepository;
 import com.halo.eventer.domain.image.dto.FileDto;
 import com.halo.eventer.domain.parking.ParkingManagement;
-import com.halo.eventer.domain.parking.dto.ParkingManagementReqDto;
-import com.halo.eventer.domain.parking.dto.ParkingManagementResDto;
-import com.halo.eventer.domain.parking.dto.ParkingManagementSubPageResDto;
-import com.halo.eventer.domain.parking.dto.ParkingMapImageReqDto;
-import com.halo.eventer.domain.parking.dto.ParkingSubPageReqDto;
+import com.halo.eventer.domain.parking.dto.common.DisplayOrderChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementReqDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementResDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingManagementSubPageResDto;
+import com.halo.eventer.domain.parking.dto.parking_management.ParkingSubPageReqDto;
 import com.halo.eventer.domain.parking.enums.ParkingInfoType;
 import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
 import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
@@ -251,8 +251,8 @@ class ParkingManagementServiceTest {
 
             given(parkingManagementRepository.findByIdWithImages(1L)).willReturn(Optional.of(pm));
 
-            var 요청 = mock(ParkingMapImageReqDto.class);
-            given(요청.getImageIds()).willReturn(List.of(30L, 10L, 20L));
+            var 요청 = mock(DisplayOrderChangeReqDto.class);
+            given(요청.getIds()).willReturn(List.of(30L, 10L, 20L));
 
             service.updateParkingMapImageDisplayOrder(1L, 요청);
 
@@ -265,7 +265,8 @@ class ParkingManagementServiceTest {
         void 이미지_표시순서_변경_실패_주차관리없음() {
             given(parkingManagementRepository.findByIdWithImages(anyLong())).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.updateParkingMapImageDisplayOrder(1L, mock(ParkingMapImageReqDto.class)))
+            assertThatThrownBy(
+                            () -> service.updateParkingMapImageDisplayOrder(1L, mock(DisplayOrderChangeReqDto.class)))
                     .isInstanceOf(ParkingManagementNotFoundException.class);
         }
 
@@ -280,8 +281,8 @@ class ParkingManagementServiceTest {
 
             given(parkingManagementRepository.findByIdWithImages(1L)).willReturn(Optional.of(pm));
 
-            var 요청 = mock(ParkingMapImageReqDto.class);
-            given(요청.getImageIds()).willReturn(List.of(1L)); // 크기 불일치
+            var 요청 = mock(DisplayOrderChangeReqDto.class);
+            given(요청.getIds()).willReturn(List.of(1L)); // 크기 불일치
 
             assertThatThrownBy(() -> service.updateParkingMapImageDisplayOrder(1L, 요청))
                     .isInstanceOf(BaseException.class);
@@ -300,8 +301,8 @@ class ParkingManagementServiceTest {
 
             given(parkingManagementRepository.findByIdWithImages(1L)).willReturn(Optional.of(pm));
 
-            var 요청 = mock(ParkingMapImageReqDto.class);
-            given(요청.getImageIds()).willReturn(List.of(10L, 30L));
+            var 요청 = mock(DisplayOrderChangeReqDto.class);
+            given(요청.getIds()).willReturn(List.of(10L, 30L));
 
             service.deleteParkingMapImages(1L, 요청);
 
@@ -314,7 +315,7 @@ class ParkingManagementServiceTest {
         void 이미지_삭제_실패_주차관리없음() {
             given(parkingManagementRepository.findByIdWithImages(anyLong())).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.deleteParkingMapImages(1L, mock(ParkingMapImageReqDto.class)))
+            assertThatThrownBy(() -> service.deleteParkingMapImages(1L, mock(DisplayOrderChangeReqDto.class)))
                     .isInstanceOf(ParkingManagementNotFoundException.class);
         }
     }

--- a/src/test/java/com/halo/eventer/domain/parking/service/ParkingNoticeServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/parking/service/ParkingNoticeServiceTest.java
@@ -1,0 +1,221 @@
+package com.halo.eventer.domain.parking.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.halo.eventer.domain.parking.ParkingManagement;
+import com.halo.eventer.domain.parking.ParkingNotice;
+import com.halo.eventer.domain.parking.dto.common.VisibilityChangeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeContentReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeReqDto;
+import com.halo.eventer.domain.parking.dto.parking_notice.ParkingNoticeResDto;
+import com.halo.eventer.domain.parking.exception.ParkingManagementNotFoundException;
+import com.halo.eventer.domain.parking.exception.ParkingNoticeNotFoundException;
+import com.halo.eventer.domain.parking.repository.ParkingManagementRepository;
+import com.halo.eventer.domain.parking.repository.ParkingNoticeRepository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class ParkingNoticeServiceTest {
+
+    @InjectMocks
+    private ParkingNoticeService service;
+
+    @Mock
+    private ParkingNoticeRepository parkingNoticeRepository;
+
+    @Mock
+    private ParkingManagementRepository parkingManagementRepository;
+
+    private ParkingManagement 주차관리;
+
+    @BeforeEach
+    void setUp() {
+        // ParkingManagement는 외부 동작만 필요하므로 mock 사용
+        주차관리 = mock(ParkingManagement.class);
+    }
+
+    @Test
+    void 공지_생성_성공() {
+        // given
+        long 관리_id = 1L;
+        given(parkingManagementRepository.findById(관리_id)).willReturn(Optional.of(주차관리));
+        given(parkingNoticeRepository.save(any(ParkingNotice.class))).willAnswer(inv -> inv.getArgument(0));
+
+        var 요청 = mock(ParkingNoticeReqDto.class);
+        given(요청.getTitle()).willReturn("제목");
+        given(요청.getContent()).willReturn("내용");
+
+        // when
+        service.create(관리_id, 요청);
+
+        // then
+        then(parkingManagementRepository).should().findById(관리_id);
+        ArgumentCaptor<ParkingNotice> captor = ArgumentCaptor.forClass(ParkingNotice.class);
+        then(parkingNoticeRepository).should().save(captor.capture());
+
+        ParkingNotice saved = captor.getValue();
+        assertThat(saved.getTitle()).isEqualTo("제목");
+        assertThat(saved.getContent()).isEqualTo("내용");
+        assertThat(saved.getVisible()).isTrue();
+        assertThat(saved.getParkingManagement()).isEqualTo(주차관리);
+    }
+
+    @Test
+    void 공지_생성_실패_주차관리없음() {
+        // given
+        given(parkingManagementRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // expect
+        assertThatThrownBy(() -> service.create(1L, mock(ParkingNoticeReqDto.class)))
+                .isInstanceOf(ParkingManagementNotFoundException.class);
+
+        then(parkingNoticeRepository).should(never()).save(any());
+    }
+
+    @Nested
+    class 조회 {
+
+        @Test
+        void 공지_목록_조회_성공() {
+            // given
+            long 관리_id = 7L;
+            var pm = mock(ParkingManagement.class);
+            var n1 = ParkingNotice.of("t1", "c1", pm);
+            var n2 = ParkingNotice.of("t2", "c2", pm);
+            ReflectionTestUtils.setField(n1, "id", 10L);
+            ReflectionTestUtils.setField(n2, "id", 20L);
+            ReflectionTestUtils.setField(n2, "visible", false);
+
+            given(parkingNoticeRepository.findByIdParkingManagementId(관리_id)).willReturn(List.of(n1, n2));
+
+            // when
+            List<ParkingNoticeResDto> res = service.getParkingNotices(관리_id);
+
+            // then
+            assertThat(res).hasSize(2);
+            assertThat(res).extracting(ParkingNoticeResDto::getId).containsExactly(10L, 20L);
+            assertThat(res).extracting(ParkingNoticeResDto::getTitle).containsExactly("t1", "t2");
+            assertThat(res).extracting(ParkingNoticeResDto::getContent).containsExactly("c1", "c2");
+            assertThat(res).extracting(ParkingNoticeResDto::getVisible).containsExactly(true, false);
+        }
+
+        @Test
+        void 가시_공지_목록_조회_성공() {
+            // given
+            long 관리_id = 8L;
+            var pm = mock(ParkingManagement.class);
+            var n1 = ParkingNotice.of("t1", "c1", pm);
+            var n2 = ParkingNotice.of("t2", "c2", pm);
+            ReflectionTestUtils.setField(n1, "id", 11L);
+            ReflectionTestUtils.setField(n2, "id", 22L);
+
+            given(parkingNoticeRepository.findByIdParkingManagementIdAndVisible(관리_id, true))
+                    .willReturn(List.of(n1, n2));
+
+            // when
+            List<ParkingNoticeResDto> res = service.getVisibleParkingNotices(관리_id);
+
+            // then
+            assertThat(res).hasSize(2);
+            assertThat(res).allMatch(dto -> dto.getVisible().equals(true));
+            assertThat(res).extracting(ParkingNoticeResDto::getId).containsExactly(11L, 22L);
+        }
+    }
+
+    @Nested
+    class 수정_및_삭제 {
+
+        @Test
+        void 내용_수정_성공() {
+            // given
+            var pm = mock(ParkingManagement.class);
+            var notice = ParkingNotice.of("old-title", "old-content", pm);
+            ReflectionTestUtils.setField(notice, "id", 100L);
+
+            given(parkingNoticeRepository.findById(100L)).willReturn(Optional.of(notice));
+
+            var 요청 = mock(ParkingNoticeContentReqDto.class);
+            given(요청.getTitle()).willReturn("new-title");
+            given(요청.getContent()).willReturn("new-content");
+
+            // when
+            service.updateContent(100L, 요청);
+
+            // then
+            assertThat(notice.getTitle()).isEqualTo("new-title");
+            assertThat(notice.getContent()).isEqualTo("new-content");
+        }
+
+        @Test
+        void 내용_수정_실패_공지없음() {
+            given(parkingNoticeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.updateContent(1L, mock(ParkingNoticeContentReqDto.class)))
+                    .isInstanceOf(ParkingNoticeNotFoundException.class);
+        }
+
+        @Test
+        void 가시성_변경_성공() {
+            // given
+            var pm = mock(ParkingManagement.class);
+            var notice = ParkingNotice.of("t", "c", pm);
+            ReflectionTestUtils.setField(notice, "id", 200L);
+
+            given(parkingNoticeRepository.findById(200L)).willReturn(Optional.of(notice));
+
+            var 요청 = mock(VisibilityChangeReqDto.class);
+            given(요청.getVisible()).willReturn(false);
+
+            // when
+            service.changeVisibility(200L, 요청);
+
+            // then
+            assertThat(notice.getVisible()).isFalse();
+        }
+
+        @Test
+        void 가시성_변경_실패_공지없음() {
+            given(parkingNoticeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.changeVisibility(1L, mock(VisibilityChangeReqDto.class)))
+                    .isInstanceOf(ParkingNoticeNotFoundException.class);
+        }
+
+        @Test
+        void 삭제_성공() {
+            // given
+            var pm = mock(ParkingManagement.class);
+            var notice = ParkingNotice.of("t", "c", pm);
+            ReflectionTestUtils.setField(notice, "id", 300L);
+
+            given(parkingNoticeRepository.findById(300L)).willReturn(Optional.of(notice));
+
+            // when
+            service.delete(300L);
+
+            // then
+            then(parkingNoticeRepository).should().delete(notice);
+        }
+
+        @Test
+        void 삭제_실패_공지없음() {
+            given(parkingNoticeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.delete(1L)).isInstanceOf(ParkingNoticeNotFoundException.class);
+
+            then(parkingNoticeRepository).should(never()).delete(any());
+        }
+    }
+}

--- a/src/test/java/com/halo/eventer/global/constants/ApiConstraint.java
+++ b/src/test/java/com/halo/eventer/global/constants/ApiConstraint.java
@@ -29,4 +29,8 @@ public class ApiConstraint {
     public static Constraint JavaxSize(int min, int max) {
         return new Constraint("javax.validation.constraints.Size", Map.of("min", min, "max", max));
     }
+
+    public static Constraint JavaxNotEmpty() {
+        return new Constraint("javax.validation.constraints.NotEmpty", Map.of());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #159 

## 📝작업 내용

백오피스용, 유저용 API를 개발하였습니다. 개발 기한으로 인해 Controller Slice Test만 진행하게 되었고 추후 다른 단위 테스트들을 추가할 예정입니다.

추가로, 순서 변경의 경우 이전 pr에서 `@OrderColumn`을 사용하기로 결정하였는데. 한 엔티티에 여러 순서가 필요한 필드가 존재할 때, 동일한 동작을 하는데 대상만 다른 메서드가 중복해서 생겨나는 것을 발견하였습니다. 그리고 동시성 부분에서도 물론 admin한명만 수정을 하더라도 순서 변경 쿼리에 대해 Lost Update가 발생할 수 있다는 것을 인지하였습니다. 따라서, 리팩토링 시점에 자식 entity에 display_order를 명시하고 낙관락을 도입하여 이를 해결하려고 합니다.

만약 더 좋은 방법이 있다면 회고할 때 같이 의논해 보는게 좋을 것 같아요

