### PR TITLE
[feat] StamUser 인증 개발

### DIFF
--- a/src/main/java/com/halo/eventer/global/security/CustomStampUserDetails.java
+++ b/src/main/java/com/halo/eventer/global/security/CustomStampUserDetails.java
@@ -1,0 +1,59 @@
+package com.halo.eventer.global.security;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.halo.eventer.domain.stamp.StampUser;
+
+public class CustomStampUserDetails implements UserDetails {
+
+    private final StampUser stampUser;
+
+    public CustomStampUserDetails(StampUser stampUser) {
+        this.stampUser = stampUser;
+    }
+
+    @Override
+    public String getUsername() {
+        return stampUser.getUuid();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Stream.of("ROLE_STAMP").map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+        // 샘플 코드
+        //                member.getAuthorities().stream()
+        //                .map(o -> new SimpleGrantedAuthority(o.getRoleName()))
+        //                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/halo/eventer/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/halo/eventer/global/security/CustomUserDetailsService.java
@@ -6,15 +6,23 @@ import org.springframework.stereotype.Component;
 
 import com.halo.eventer.domain.member.exception.MemberNotFoundException;
 import com.halo.eventer.domain.member.repository.MemberRepository;
+import com.halo.eventer.domain.stamp.exception.StampUserNotFoundException;
+import com.halo.eventer.domain.stamp.repository.StampUserRepository;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
+    private final StampUserRepository stampUserRepository;
 
     @Override
     public UserDetails loadUserByUsername(String loginId) {
         return new CustomUserDetails(memberRepository.findByLoginId(loginId).orElseThrow(MemberNotFoundException::new));
+    }
+
+    public UserDetails loadUserByUuid(String Uuid) {
+        return new CustomStampUserDetails(
+                stampUserRepository.findByUuid(Uuid).orElseThrow(StampUserNotFoundException::new));
     }
 }

--- a/src/main/java/com/halo/eventer/global/security/provider/JwtProvider.java
+++ b/src/main/java/com/halo/eventer/global/security/provider/JwtProvider.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import com.halo.eventer.global.error.ErrorCode;
+import com.halo.eventer.global.error.exception.BaseException;
 import com.halo.eventer.global.security.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -60,6 +62,31 @@ public class JwtProvider {
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
+    }
+
+    public String getRole(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        Object raw = claims.get("roles");
+        String role;
+
+        if (raw instanceof List<?> list) {
+            if (list.isEmpty()) throw new BaseException(ErrorCode.UN_AUTHENTICATED);
+            role = String.valueOf(list.get(0)).trim();
+        } else if (raw instanceof String s) {
+            role = s.trim();
+        } else {
+            throw new BaseException(ErrorCode.UN_AUTHENTICATED);
+        }
+
+        if (role.isEmpty()) {
+            throw new BaseException(ErrorCode.UN_AUTHENTICATED);
+        }
+        return role;
     }
 
     // 토큰 검증
@@ -118,7 +145,14 @@ public class JwtProvider {
     // 권한정보 획득
     // Spring Security 인증과정에서 권한확인을 위한 기능
     public Authentication getAuthentication(String token) {
-        UserDetails userDetails = customUserDetailService.loadUserByUsername(this.getAccount(token));
+        String role = this.getRole(token);
+        UserDetails userDetails;
+        if (role.equals("STAMP")) {
+            System.out.println("stamp");
+            userDetails = customUserDetailService.loadUserByUuid(this.getAccount(token));
+        } else {
+            userDetails = customUserDetailService.loadUserByUsername(this.getAccount(token));
+        }
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }

--- a/src/test/java/com/halo/eventer/global/security/JwtProviderTest.java
+++ b/src/test/java/com/halo/eventer/global/security/JwtProviderTest.java
@@ -1,0 +1,44 @@
+package com.halo.eventer.global.security;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.halo.eventer.global.security.provider.JwtProvider;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings("NonAsciiCharacters")
+@ActiveProfiles("deploy")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Disabled
+public class JwtProviderTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @Test
+    void 토큰_전달_테스트() throws Exception {
+        String token = jwtProvider.createToken("admin", List.of("ADMIN"));
+
+        mockMvc.perform(get("/").header("Authorization", "Bearer " + token)).andExpect(status().isOk());
+    }
+
+    @Test
+    void STAMP_토큰_전달_테스트() throws Exception {
+        String token = jwtProvider.createToken("uuid", List.of("STAMP"));
+
+        mockMvc.perform(get("/").header("Authorization", "Bearer " + token)).andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #166 

## 📝작업 내용

StampUser 개발시 고려사항

1. 토큰 생성시 account에는 유저 uuid 담기 (JwtProvider.createToken() 메서드 사용)
2. roles에는 STAMP_USER 담기 → db 필드에도 저장해주기

관련 코드
```java
public String createToken(String account, List<String> roles) {
    Claims claims = Jwts.claims().setSubject(account);
    claims.put("roles", roles);
    Date now = new Date();
    return Jwts.builder()
            .setClaims(claims)
            .setIssuedAt(now)
            .setExpiration(new Date(now.getTime() + 3600000)) // 만료기간
            .signWith(key, SignatureAlgorithm.HS256)
            .compact();
}
```

아래 파일의 코드를 일부 수정해야함
    
```java
com.halo.eventer.global.security.CustomStampUserDetails
```

이 부분 `getAuthorities()` 를 일단 무조건 ROLE_STAMP 보내도록 해놓음
    

JwtProvider.getAuthentication()에서 role에 따라 분기하도록 구현해서 나중에 SpringSecurity 관련 학습을 더 진행하고 리팩토링이 필요해 보입니다. 지금은 일단 오늘 마감을 해야하기에 권한이 무조건 하나만 들어오는 상황으로 가정하고 간단하게 구현하였습니다.
    
```java
public Authentication getAuthentication(String token) {
        String role = this.getRole(token);
        UserDetails userDetails;
        if (role.equals("STAMP")) {
            System.out.println("stamp");
            userDetails = customUserDetailService.loadUserByUuid(this.getAccount(token));
        }
        else{
            userDetails = customUserDetailService.loadUserByUsername(this.getAccount(token));
        }
        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
    }
```