### PR TITLE
[feat] 필드명 통일 및 RestDocs 설명 추가 (#174)

### DIFF
--- a/src/main/java/com/halo/eventer/domain/parking/enums/CongestionLevel.java
+++ b/src/main/java/com/halo/eventer/domain/parking/enums/CongestionLevel.java
@@ -4,5 +4,6 @@ public enum CongestionLevel {
     LOW,
     MEDIUM,
     HIGH,
-    FULL
+    FULL,
+    CLOSED
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/Button.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/Button.java
@@ -64,14 +64,14 @@ public class Button {
 
     public static Button from(PageTemplate template, ButtonReqDto dto) {
         Button b = new Button(
-                dto.getSequenceIndex(), dto.getIconImg(), dto.getContent(), dto.getAction(), dto.getTargetUrl());
+                dto.getSequenceIndex(), dto.getIconImgUrl(), dto.getContent(), dto.getAction(), dto.getTargetUrl());
         b.attachTo(template);
         return b;
     }
 
     public static Button from(MissionDetailsTemplate template, ButtonReqDto dto) {
         Button b = new Button(
-                dto.getSequenceIndex(), dto.getIconImg(), dto.getContent(), dto.getAction(), dto.getTargetUrl());
+                dto.getSequenceIndex(), dto.getIconImgUrl(), dto.getContent(), dto.getAction(), dto.getTargetUrl());
         b.attachTo(template);
         return b;
     }

--- a/src/main/java/com/halo/eventer/domain/stamp/Mission.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/Mission.java
@@ -26,16 +26,16 @@ public class Mission {
     private String time;
     private String clearedThumbnail;
     private String notClearedThumbnail;
-    private boolean show = true;
-    private boolean showTitle = true;
+    private Boolean show = true;
+    private Boolean showTitle = true;
     private int requiredSuccessCount = 0;
-    private boolean showRequiredSuccessCount = true;
+    private Boolean showRequiredSuccessCount = true;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "stamp_id")
+    @JoinColumn(name = "stamp_id", nullable = false)
     private Stamp stamp;
 
-    @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MissionDetailsTemplate> missionDetailsTemplates = new ArrayList<>();
 
     @Builder
@@ -108,9 +108,10 @@ public class Mission {
                 .build();
     }
 
-    public static Mission from(Stamp stamp, String missionName) {
+    public static Mission from(Stamp stamp, String missionName, Boolean showMission) {
         Mission mission = Mission.builder().title(missionName).build();
         mission.addStamp(stamp);
+        mission.updateMissionShow(showMission);
         return mission;
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/MissionDetailsTemplate.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/MissionDetailsTemplate.java
@@ -28,8 +28,8 @@ public class MissionDetailsTemplate {
     @Enumerated(EnumType.STRING)
     private MissionDetailsDesignLayout designLayout;
 
-    private boolean showExtraInfos = true;
-    private boolean showButtons = true;
+    private Boolean showExtraInfos = true;
+    private Boolean showButtons = true;
 
     @Enumerated(EnumType.STRING)
     private MediaSpec mediaSpec = MediaSpec.NONE;
@@ -143,10 +143,10 @@ public class MissionDetailsTemplate {
 
     public static MissionDetailsTemplate from(MissionDetailsTemplateReqDto request) {
         return MissionDetailsTemplate.builder()
-                .layout(request.getLayout())
+                .layout(request.getMissionDetailsDesignLayout())
                 .showExtraInfos(request.isShowExtraInfos())
                 .showButtons(request.isShowButtons())
-                .mediaSpec(request.getMissionMediaSpec())
+                .mediaSpec(request.getMediaSpec())
                 .mediaUrl(request.getMediaUrl())
                 .type(request.getExtraInfoType())
                 .build();

--- a/src/main/java/com/halo/eventer/domain/stamp/PageTemplate.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/PageTemplate.java
@@ -63,7 +63,7 @@ public class PageTemplate {
     }
 
     public void updateLandingPageTemplate(StampTourLandingPageReqDto request) {
-        this.landingPageDesignTemplate = request.getDesignTemplate();
+        this.landingPageDesignTemplate = request.getLandingPageDesignTemplate();
         this.backgroundImg = request.getBackgroundImgUrl();
         this.iconImg = request.getIconImgUrl();
         this.description = request.getDescription();
@@ -74,7 +74,7 @@ public class PageTemplate {
     }
 
     public void updateMainPageTemplate(StampTourMainPageReqDto request) {
-        this.mainPageDesignTemplate = request.getDesignTemplate();
+        this.mainPageDesignTemplate = request.getMainPageDesignTemplate();
         this.backgroundImg = request.getBackgroundImgUrl();
         this.buttonLayout = request.getButtonLayout();
         if (!request.getButtonLayout().equals(ButtonLayout.NONE)) {

--- a/src/main/java/com/halo/eventer/domain/stamp/StampMissionBasicSetting.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/StampMissionBasicSetting.java
@@ -22,7 +22,7 @@ public class StampMissionBasicSetting {
     @Enumerated(EnumType.STRING)
     private MissionDetailsDesignLayout defaultDetailLayout = MissionDetailsDesignLayout.CARD;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stamp_id", nullable = false, unique = true)
     private Stamp stamp;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/StampUser.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/StampUser.java
@@ -35,7 +35,7 @@ public class StampUser extends BaseTime {
     @Column(nullable = false)
     private String name;
 
-    private boolean isFinished = false;
+    private Boolean isFinished = false;
 
     private int participantCount = 1;
 
@@ -103,7 +103,7 @@ public class StampUser extends BaseTime {
     }
 
     public boolean isMissionsAllCompleted() {
-        return userMissions.stream().allMatch(UserMission::isComplete);
+        return userMissions.stream().allMatch(UserMission::getIsComplete);
     }
 
     public void completeUserMission(Long userMissionId) {
@@ -115,7 +115,8 @@ public class StampUser extends BaseTime {
     }
 
     public boolean canFinishTour() {
-        long completed = userMissions.stream().filter(UserMission::isComplete).count();
+        long completed =
+                userMissions.stream().filter(UserMission::getIsComplete).count();
         if (completed >= stamp.getFinishCount()) {
             isFinished = true;
             return true;

--- a/src/main/java/com/halo/eventer/domain/stamp/UserMission.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/UserMission.java
@@ -18,7 +18,7 @@ public class UserMission {
     private Long id;
 
     @Column(nullable = false)
-    private boolean isComplete = false;
+    private Boolean isComplete = false;
 
     private int successCount = 0;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/controller/v2/StampMissionAdminController.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/controller/v2/StampMissionAdminController.java
@@ -23,13 +23,20 @@ public class StampMissionAdminController {
             @PathVariable @Min(1) long festivalId,
             @PathVariable @Min(1) long stampId,
             @RequestBody @Valid MissionCreateReqDto request) {
-        stampMissionAdminService.createMission(festivalId, stampId, request.getName());
+        stampMissionAdminService.createMission(festivalId, stampId, request.getTitle(), request.getShowMission());
     }
 
     @GetMapping
-    public List<MissionBriefResDto> getMissionList(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+    public MissionListResDto getMissionList(@PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
         return stampMissionAdminService.getMissions(festivalId, stampId);
+    }
+
+    @DeleteMapping("/{missionId}")
+    public void deleteMission(
+            @PathVariable @Min(1) long festivalId,
+            @PathVariable @Min(1) long stampId,
+            @PathVariable @Min(1) long missionId) {
+        stampMissionAdminService.deleteMission(festivalId, stampId, missionId);
     }
 
     @PatchMapping("/{missionId}/show")

--- a/src/main/java/com/halo/eventer/domain/stamp/controller/v2/StampTourTemplateController.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/controller/v2/StampTourTemplateController.java
@@ -27,45 +27,45 @@ public class StampTourTemplateController {
         return templateService.getStampTourList(festivalId);
     }
 
-    @GetMapping("/{stampTourId}/signup")
+    @GetMapping("/{stampId}/signup")
     public StampTourSignUpTemplateResDto getSignUpSettings(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampTourId) {
-        return templateService.getSignupTemplate(festivalId, stampTourId);
+            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+        return templateService.getSignupTemplate(festivalId, stampId);
     }
 
-    @GetMapping("/{stampTourId}/landing")
+    @GetMapping("/{stampId}/landing")
     public StampTourLandingPageResDto getStampTourLandingPage(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampTourId) {
-        return templateService.getLandingPage(festivalId, stampTourId);
+            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+        return templateService.getLandingPage(festivalId, stampId);
     }
 
-    @GetMapping("/{stampTourId}/join-template")
+    @GetMapping("/{stampId}/join-template")
     public StampTourJoinTemplateResDto getStampUserJoinTemplate(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampTourId) {
-        return templateService.getStampTourJoinMethod(festivalId, stampTourId);
+            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+        return templateService.getStampTourJoinMethod(festivalId, stampId);
     }
 
-    @GetMapping("/{stampTourId}/auth-method")
+    @GetMapping("/{stampId}/auth-method")
     public StampTourAuthMethodResDto getStampTourAuthMethod(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampTourId) {
-        return templateService.getAuthMethod(festivalId, stampTourId);
+            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+        return templateService.getAuthMethod(festivalId, stampId);
     }
 
-    @GetMapping("/{stampTourId}/main")
+    @GetMapping("/{stampId}/main")
     public StampTourMainPageResDto getStampTourMainPage(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampTourId) {
-        return templateService.getMainPage(festivalId, stampTourId);
+            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+        return templateService.getMainPage(festivalId, stampId);
     }
 
-    @GetMapping("/{stampTourId}/notice")
+    @GetMapping("/{stampId}/notice")
     public StampTourNotificationResDto getStampTourNotification(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampTourId) {
-        return templateService.getStampTourNotification(festivalId, stampTourId);
+            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+        return templateService.getStampTourNotification(festivalId, stampId);
     }
 
-    @GetMapping("/{stampTourId}/guide")
+    @GetMapping("/{stampId}/guide")
     public StampTourGuideResDto getStampTourParticipationGuide(
-            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampTourId) {
-        return templateService.getParticipateGuide(festivalId, stampTourId);
+            @PathVariable @Min(1) long festivalId, @PathVariable @Min(1) long stampId) {
+        return templateService.getParticipateGuide(festivalId, stampId);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/controller/v2/StampTourUserController.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/controller/v2/StampTourUserController.java
@@ -27,56 +27,55 @@ public class StampTourUserController {
 
     private final StampTourUserService stampTourUserService;
 
-    @PostMapping("/{stampTourId}/signup")
+    @PostMapping("/{stampId}/signup")
     public void stampUserSignup(
             @PathVariable @Min(1) long festivalId,
-            @PathVariable @Min(1) long stampTourId,
+            @PathVariable @Min(1) long stampId,
             @RequestBody @Valid StampUserSignupReqDto request) {
-        stampTourUserService.signup(festivalId, stampTourId, request);
+        stampTourUserService.signup(festivalId, stampId, request);
     }
 
-    @PostMapping("/{stampTourId}/login")
+    @PostMapping("/{stampId}/login")
     public StampUserGetDto login(
             @PathVariable @Min(1) long festivalId,
-            @PathVariable @Min(1) long stampTourId,
+            @PathVariable @Min(1) long stampId,
             @RequestBody @Valid StampUserLoginDto request,
             HttpServletResponse response) {
-        return stampTourUserService.login(festivalId, stampTourId, request, response);
+        return stampTourUserService.login(festivalId, stampId, request, response);
     }
 
-    @GetMapping("/{stampTourId}/missions")
+    @GetMapping("/{stampId}/missions")
     public MissionBoardResDto getUserMissionBoard(
             @AuthenticationPrincipal CustomStampUserDetails userDetails,
             @PathVariable @Min(1) long festivalId,
-            @PathVariable @Min(1) long stampTourId) {
-        return stampTourUserService.getMissionBoard(festivalId, stampTourId, userDetails.getUsername());
+            @PathVariable @Min(1) long stampId) {
+        return stampTourUserService.getMissionBoard(festivalId, stampId, userDetails.getUsername());
     }
 
-    @GetMapping("/{stampTourId}/missions/{missionId}")
+    @GetMapping("/{stampId}/missions/{missionId}")
     public MissionTemplateResDto getMissionDetails(
             @AuthenticationPrincipal CustomStampUserDetails userDetails,
             @PathVariable @Min(1) long festivalId,
-            @PathVariable @Min(1) long stampTourId,
+            @PathVariable @Min(1) long stampId,
             @PathVariable @Min(1) long missionId) {
-        return stampTourUserService.getMissionsTemplate(festivalId, stampTourId, missionId, userDetails.getUsername());
+        return stampTourUserService.getMissionsTemplate(festivalId, stampId, missionId, userDetails.getUsername());
     }
 
     // TODO : QR 인증방식 변경 필요 : 토큰 방식 고려 중
-    @PatchMapping("/{stampTourId}/verify/qr")
+    @PatchMapping("/{stampId}/verify/qr")
     public void successMissionVerifyByQr(
             @AuthenticationPrincipal CustomStampUserDetails userDetails,
             @PathVariable @Min(1) long festivalId,
-            @PathVariable @Min(1) long stampTourId,
+            @PathVariable @Min(1) long stampId,
             @RequestBody @Valid MissionQrVerifyReqDto request) {
-        stampTourUserService.successMissionByQr(
-                festivalId, stampTourId, request.getMissionId(), userDetails.getUsername());
+        stampTourUserService.successMissionByQr(festivalId, stampId, request.getMissionId(), userDetails.getUsername());
     }
 
-    @GetMapping("/{stampTourId}/prizes/qr")
+    @GetMapping("/{stampId}/prizes/qr")
     public PrizeClaimQrResDto getStampUserPrizeQrInfo(
             @AuthenticationPrincipal CustomStampUserDetails userDetails,
             @PathVariable @Min(1) long festivalId,
-            @PathVariable @Min(1) long stampTourId) {
-        return stampTourUserService.getPrizeReceiveQr(festivalId, stampTourId, userDetails.getUsername());
+            @PathVariable @Min(1) long stampId) {
+        return stampTourUserService.getPrizeReceiveQr(festivalId, stampId, userDetails.getUsername());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/MissionBasicSettingsReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/MissionBasicSettingsReqDto.java
@@ -18,5 +18,5 @@ public class MissionBasicSettingsReqDto {
     private int missionCount;
 
     @NotNull
-    private MissionDetailsDesignLayout defaultDetailLayout;
+    private MissionDetailsDesignLayout missionDetailsDesignLayout;
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/MissionCreateReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/MissionCreateReqDto.java
@@ -1,5 +1,6 @@
 package com.halo.eventer.domain.stamp.dto.mission.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
@@ -10,6 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MissionCreateReqDto {
+    @NotBlank
+    private String title;
+
     @NotNull
-    private String name;
+    private Boolean showMission;
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/MissionDetailsTemplateReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/MissionDetailsTemplateReqDto.java
@@ -19,18 +19,18 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MissionDetailsTemplateReqDto {
     @NotNull
-    private MissionDetailsDesignLayout layout;
+    private MissionDetailsDesignLayout missionDetailsDesignLayout;
 
     @NotEmpty
     private String missionTitle;
 
-    private boolean showMissionName;
+    private boolean showMissionTitle;
     private boolean showSuccessCount;
     private boolean showExtraInfos;
     private boolean showButtons;
 
     @NotNull
-    private MediaSpec missionMediaSpec;
+    private MediaSpec mediaSpec;
 
     private String mediaUrl;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/StampMissionClearImageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/request/StampMissionClearImageReqDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StampMissionClearImageReqDto {
-    private boolean showMissionName;
+    private boolean showMissionTitle;
     private String clearedThumbnail;
     private String notClearedThumbnail;
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionBoardResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionBoardResDto.java
@@ -19,7 +19,7 @@ public class MissionBoardResDto {
 
     public static MissionBoardResDto from(List<UserMission> list) {
         int total = list.size();
-        int done = (int) list.stream().filter(UserMission::isComplete).count();
+        int done = (int) list.stream().filter(UserMission::getIsComplete).count();
         return new MissionBoardResDto(
                 done,
                 total,

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionBriefResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionBriefResDto.java
@@ -1,7 +1,6 @@
 package com.halo.eventer.domain.stamp.dto.mission.response;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.halo.eventer.domain.stamp.Mission;
 import lombok.AllArgsConstructor;
@@ -14,12 +13,15 @@ import lombok.NoArgsConstructor;
 public class MissionBriefResDto {
     private Long missionId;
     private String title;
+    private Boolean showMission;
+    private Boolean showMissionTitle;
 
     public static List<MissionBriefResDto> fromEntities(List<Mission> missions) {
-        return missions.stream().map(MissionBriefResDto::from).collect(Collectors.toList());
+        if (missions == null || missions.isEmpty()) return List.of();
+        return missions.stream().map(MissionBriefResDto::from).toList();
     }
 
     public static MissionBriefResDto from(Mission mission) {
-        return new MissionBriefResDto(mission.getId(), mission.getTitle());
+        return new MissionBriefResDto(mission.getId(), mission.getTitle(), mission.getShow(), mission.getShowTitle());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionDetailsTemplateResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionDetailsTemplateResDto.java
@@ -16,11 +16,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MissionDetailsTemplateResDto {
-    private long templateId;
-    private MissionDetailsDesignLayout layout;
+    private MissionDetailsDesignLayout missionDetailsDesignLayout;
 
-    private boolean showMissionName;
-    private String missionName;
+    private boolean showMissionTitle;
+    private String missionTitle;
 
     private boolean showSuccessCount;
 
@@ -38,17 +37,16 @@ public class MissionDetailsTemplateResDto {
     public static MissionDetailsTemplateResDto from(
             MissionDetailsTemplate template, boolean showTitle, boolean showSuccessCount, String missionName) {
         return new MissionDetailsTemplateResDto(
-                template.getId(),
                 template.getDesignLayout(),
                 showTitle,
                 missionName,
                 showSuccessCount,
                 template.getMediaSpec(),
                 template.getMediaUrl(),
-                template.isShowExtraInfos(),
+                template.getShowExtraInfos(),
                 template.getInfoLayout(),
                 MissionExtraInfoSummaryResDto.fromEntities(template.getExtraInfo()),
-                template.isShowButtons(),
+                template.getShowButtons(),
                 template.getButtonLayout(),
                 ButtonResDto.fromEntities(template.getButtons()));
     }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionIconRes.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionIconRes.java
@@ -17,7 +17,7 @@ public class MissionIconRes {
 
     public static MissionIconRes from(UserMission um) {
         Mission m = um.getMission();
-        String url = um.isComplete() ? m.getClearedThumbnail() : m.getNotClearedThumbnail();
-        return new MissionIconRes(m.getId(), m.getTitle(), um.isComplete(), url);
+        String url = um.getIsComplete() ? m.getClearedThumbnail() : m.getNotClearedThumbnail();
+        return new MissionIconRes(m.getId(), m.getTitle(), um.getIsComplete(), url);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionListResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionListResDto.java
@@ -1,0 +1,15 @@
+package com.halo.eventer.domain.stamp.dto.mission.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MissionListResDto {
+    private int limitMissionCount;
+    private List<MissionBriefResDto> missionList;
+}

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionPrizeResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionPrizeResDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class MissionPrizeResDto {
     private long id;
     private int requiredCount;
-    private String description;
+    private String prizeDescription;
 
     public static MissionPrizeResDto from(StampMissionPrize prize) {
         return new MissionPrizeResDto(prize.getId(), prize.getRequiredCount(), prize.getDescription());

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionQrDataResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionQrDataResDto.java
@@ -19,6 +19,9 @@ public class MissionQrDataResDto {
     }
 
     public static List<MissionQrDataResDto> fromEntities(List<Mission> missions) {
+        if (missions == null || missions.isEmpty()) {
+            return List.of();
+        }
         return missions.stream().map(MissionQrDataResDto::from).toList();
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionTemplateResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/MissionTemplateResDto.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MissionTemplateResDto {
-    private long missionId;
+    private Long missionId;
     private String title;
 
     private String mediaUrl;

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/StampMissionBasicSettingsResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/StampMissionBasicSettingsResDto.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StampMissionBasicSettingsResDto {
     private int missionCount;
-    private MissionDetailsDesignLayout layout;
+    private MissionDetailsDesignLayout missionDetailsDesignLayout;
     private List<MissionPrizeResDto> prizes;
 
     public static StampMissionBasicSettingsResDto from(StampMissionBasicSetting setting, Stamp stamp) {

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/StampMissionClearImageResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/mission/response/StampMissionClearImageResDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StampMissionClearImageResDto {
-    private boolean showMissionName;
+    private Boolean showMissionTitle;
     private String clearedThumbnail;
     private String notClearedThumbnail;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampGetDto.java
@@ -21,6 +21,6 @@ public class StampGetDto {
     }
 
     public static StampGetDto from(Stamp stamp) {
-        return new StampGetDto(stamp.getId(), stamp.isActive(), stamp.getFinishCount());
+        return new StampGetDto(stamp.getId(), stamp.getActive(), stamp.getFinishCount());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampUsersGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/StampUsersGetDto.java
@@ -27,7 +27,7 @@ public class StampUsersGetDto {
                 stampUser.getUuid(),
                 stampUser.getName(),
                 stampUser.getPhone(),
-                stampUser.isFinished(),
+                stampUser.getIsFinished(),
                 stampUser.getParticipantCount());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/ButtonReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/ButtonReqDto.java
@@ -1,8 +1,5 @@
 package com.halo.eventer.domain.stamp.dto.stamp.request;
 
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-
 import com.halo.eventer.domain.stamp.dto.stamp.enums.ButtonAction;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,16 +9,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ButtonReqDto {
-    @NotNull
     private int sequenceIndex;
 
-    @NotEmpty
-    private String iconImg;
+    private String iconImgUrl;
 
-    @NotEmpty
     private String content;
 
-    @NotNull
     private ButtonAction action;
 
     private String targetUrl;

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourBasicUpdateReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourBasicUpdateReqDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StampTourBasicUpdateReqDto {
     @NotNull
-    private boolean isStampActivate;
+    private Boolean stampActivate;
 
     @NotBlank
     private String title;

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourCreateReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourCreateReqDto.java
@@ -1,6 +1,7 @@
 package com.halo.eventer.domain.stamp.dto.stamp.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,5 +14,6 @@ public class StampTourCreateReqDto {
     @NotBlank
     private String title;
 
-    private boolean showStamp;
+    @NotNull
+    private Boolean showStamp;
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourLandingPageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourLandingPageReqDto.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StampTourLandingPageReqDto {
     @NotNull
-    private LandingPageDesignTemplate designTemplate;
+    private LandingPageDesignTemplate landingPageDesignTemplate;
 
     @NotEmpty
     private String backgroundImgUrl;

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourMainPageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourMainPageReqDto.java
@@ -1,7 +1,6 @@
 package com.halo.eventer.domain.stamp.dto.stamp.request;
 
 import java.util.List;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -16,7 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StampTourMainPageReqDto {
     @NotNull
-    private MainPageDesignTemplate designTemplate;
+    private MainPageDesignTemplate mainPageDesignTemplate;
 
     @NotEmpty
     private String backgroundImgUrl;
@@ -24,5 +23,5 @@ public class StampTourMainPageReqDto {
     @NotNull
     private ButtonLayout buttonLayout;
 
-    private List<@Valid ButtonReqDto> buttons;
+    private List<ButtonReqDto> buttons;
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourParticipateGuidePageReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourParticipateGuidePageReqDto.java
@@ -12,8 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StampTourParticipateGuidePageReqDto {
-    private long guideId;
-
     @NotBlank
     private String title;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourParticipateGuideReqDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/request/StampTourParticipateGuideReqDto.java
@@ -13,8 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StampTourParticipateGuideReqDto {
     @NotNull
-    private GuideDesignTemplate template;
+    private GuideDesignTemplate guideDesignTemplate;
 
     @NotNull
-    private GuideSlideMethod method;
+    private GuideSlideMethod guideSlideMethod;
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/ParticipateGuidePageDetailsResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/ParticipateGuidePageDetailsResDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ParticipateGuidePageDetailsResDto {
-    private long pageId;
+    private Long pageId;
     private String title;
     private MediaSpec mediaSpec;
     private String mediaUrl;

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/ParticipateGuidePageSummaryResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/ParticipateGuidePageSummaryResDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ParticipateGuidePageSummaryResDto {
-    private long pageId;
+    private Long pageId;
     private String title;
     private int displayOrder;
 

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourLandingPageResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourLandingPageResDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StampTourLandingPageResDto {
-    private LandingPageDesignTemplate designTemplate;
+    private LandingPageDesignTemplate landingPageDesignTemplate;
     private String iconImgUrl;
     private String backgroundImgUrl;
     private String description;

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourMainPageResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourMainPageResDto.java
@@ -3,6 +3,7 @@ package com.halo.eventer.domain.stamp.dto.stamp.response;
 import java.util.List;
 
 import com.halo.eventer.domain.stamp.PageTemplate;
+import com.halo.eventer.domain.stamp.dto.stamp.enums.ButtonLayout;
 import com.halo.eventer.domain.stamp.dto.stamp.enums.MainPageDesignTemplate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,16 +11,16 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class StampTourMainPageResDto {
-    private MainPageDesignTemplate designTemplate;
-    private String backgroundImg;
-    private String buttonLayout;
+    private MainPageDesignTemplate mainPageDesignTemplate;
+    private String backgroundImgUrl;
+    private ButtonLayout buttonLayout;
     private List<ButtonResDto> buttons;
 
     public static StampTourMainPageResDto from(PageTemplate pageTemplate) {
         return new StampTourMainPageResDto(
                 pageTemplate.getMainPageDesignTemplate(),
                 pageTemplate.getBackgroundImg(),
-                pageTemplate.getButtonLayout().name(),
+                pageTemplate.getButtonLayout(),
                 ButtonResDto.fromEntities(pageTemplate.getButtons()));
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourParticipateGuideResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourParticipateGuideResDto.java
@@ -13,14 +13,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StampTourParticipateGuideResDto {
-    private long participateGuideId;
     private GuideDesignTemplate guideDesignTemplate;
     private GuideSlideMethod guideSlideMethod;
     private List<ParticipateGuidePageSummaryResDto> participateGuidePages;
 
     public static StampTourParticipateGuideResDto from(ParticipateGuide guide) {
         return new StampTourParticipateGuideResDto(
-                guide.getId(),
                 guide.getGuideDesignTemplate(),
                 guide.getGuideSlideMethod(),
                 ParticipateGuidePageSummaryResDto.fromEntities(guide.getParticipateGuidePages()));

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourSettingBasicResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourSettingBasicResDto.java
@@ -10,8 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StampTourSettingBasicResDto {
-    private long stampTourId;
-    private boolean isStampActive;
+    private Long stampId;
+    private Boolean stampActive;
     private String title;
     private AuthMethod authMethod;
     private String prizeReceiptAuthPassword;
@@ -19,7 +19,7 @@ public class StampTourSettingBasicResDto {
     public static StampTourSettingBasicResDto from(Stamp stamp) {
         return new StampTourSettingBasicResDto(
                 stamp.getId(),
-                stamp.isActive(),
+                stamp.getActive(),
                 stamp.getTitle(),
                 stamp.getAuthMethod(),
                 stamp.getPrizeReceiptAuthPassword());

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourSummaryResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stamp/response/StampTourSummaryResDto.java
@@ -12,12 +12,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StampTourSummaryResDto {
-    private Long stampTourId;
+    private Long stampId;
     private String title;
-    private boolean showStamp;
+    private Boolean showStamp;
 
     public static StampTourSummaryResDto from(Stamp stamp) {
-        return new StampTourSummaryResDto(stamp.getId(), stamp.getTitle(), stamp.isActive());
+        return new StampTourSummaryResDto(stamp.getId(), stamp.getTitle(), stamp.getActive());
     }
 
     public static List<StampTourSummaryResDto> fromEntities(List<Stamp> stamps) {

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/StampUserGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/StampUserGetDto.java
@@ -23,7 +23,7 @@ public class StampUserGetDto {
         return StampUserGetDto.builder()
                 .uuid(stampUser.getUuid())
                 .participantCount(stampUser.getParticipantCount())
-                .finished(stampUser.isFinished())
+                .finished(stampUser.getIsFinished())
                 .userMissionInfoGetDtos(UserMissionInfoGetDto.fromEntities(stampUser.getUserMissions()))
                 .build();
     }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/UserMissionInfoGetDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/UserMissionInfoGetDto.java
@@ -17,7 +17,7 @@ public class UserMissionInfoGetDto {
 
     public static List<UserMissionInfoGetDto> fromEntities(List<UserMission> userMissions) {
         return userMissions.stream()
-                .map(um -> new UserMissionInfoGetDto(um.getId(), um.getMission().getId(), um.isComplete()))
+                .map(um -> new UserMissionInfoGetDto(um.getId(), um.getMission().getId(), um.getIsComplete()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/UserMissionInfoWithFinishedGetListDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/UserMissionInfoWithFinishedGetListDto.java
@@ -19,7 +19,7 @@ public class UserMissionInfoWithFinishedGetListDto {
 
     public static UserMissionInfoWithFinishedGetListDto from(StampUser stampUser) {
         return UserMissionInfoWithFinishedGetListDto.builder()
-                .finished(stampUser.isFinished())
+                .finished(stampUser.getIsFinished())
                 .userMissionInfoGetDtos(UserMissionInfoGetDto.fromEntities(stampUser.getUserMissions()))
                 .build();
     }

--- a/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/response/StampUserSummaryResDto.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/dto/stampUser/response/StampUserSummaryResDto.java
@@ -21,6 +21,6 @@ public class StampUserSummaryResDto {
                 stampUser.getName(),
                 stampUser.getPhone(),
                 stampUser.getUuid(),
-                stampUser.isFinished());
+                stampUser.getIsFinished());
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/exception/StampNotInFestivalException.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/exception/StampNotInFestivalException.java
@@ -1,0 +1,9 @@
+package com.halo.eventer.domain.stamp.exception;
+
+import com.halo.eventer.global.error.exception.InvalidInputException;
+
+public class StampNotInFestivalException extends InvalidInputException {
+    public StampNotInFestivalException(Long stampId, Long festivalId) {
+        super(String.format("Stamp %s is not in Festival %s", stampId, festivalId));
+    }
+}

--- a/src/main/java/com/halo/eventer/domain/stamp/repository/StampMissionPrizeRepository.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/repository/StampMissionPrizeRepository.java
@@ -1,11 +1,17 @@
 package com.halo.eventer.domain.stamp.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.halo.eventer.domain.stamp.StampMissionPrize;
 
 public interface StampMissionPrizeRepository extends JpaRepository<StampMissionPrize, Long> {
     List<StampMissionPrize> findAllByStampIdOrderByRequiredCountAsc(Long stampId);
+
+    @Query("select p from StampMissionPrize p where p.id = :prizeId and p.stamp.id = :stampId")
+    Optional<StampMissionPrize> findByIdAndStampId(@Param("prizeId") Long prizeId, @Param("stampId") Long stampId);
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/service/StampService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/StampService.java
@@ -78,7 +78,7 @@ public class StampService {
                         user.getUuid(),
                         encryptService.decryptInfo(user.getName()),
                         encryptService.decryptInfo(user.getPhone()),
-                        user.isFinished(),
+                        user.getIsFinished(),
                         user.getParticipantCount()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/halo/eventer/domain/stamp/service/StampUserService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/StampUserService.java
@@ -68,7 +68,7 @@ public class StampUserService {
                         user.getUuid(),
                         encryptService.decryptInfo(user.getName()),
                         encryptService.decryptInfo(user.getPhone()),
-                        user.isFinished(),
+                        user.getIsFinished(),
                         user.getParticipantCount()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampMissionAdminService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampMissionAdminService.java
@@ -26,23 +26,31 @@ public class StampMissionAdminService {
     private final MissionExtraInfoRepository extraInfoRepository;
 
     @Transactional
-    public void createMission(long festivalId, long stampId, String missionName) {
-        Stamp stamp = loadStampOrThrow(stampId);
-        stamp.ensureStampInFestival(festivalId);
-        Mission mission = Mission.from(stamp, missionName);
+    public void createMission(long festivalId, long stampId, String missionName, Boolean showMission) {
+        Stamp stamp = ensureStamp(festivalId, stampId);
+        Mission mission = Mission.from(stamp, missionName, showMission);
         missionRepository.save(mission);
     }
 
     @Transactional(readOnly = true)
-    public List<MissionBriefResDto> getMissions(long festival, long stampId) {
-        ensureStamp(festival, stampId);
-        List<Mission> missions = missionRepository.findAllByStampId(stampId);
-        return MissionBriefResDto.fromEntities(missions);
+    public MissionListResDto getMissions(long festivalId, long stampId) {
+        Stamp stamp = ensureStamp(festivalId, stampId);
+        StampMissionBasicSetting setting = loadSettingOrThrow(stampId);
+        List<Mission> missions = loadAllMissions(stampId);
+        List<MissionBriefResDto> missionList = MissionBriefResDto.fromEntities(missions);
+        return new MissionListResDto(setting.getMissionCount(), missionList);
     }
 
     @Transactional
-    public void toggleMissionShowing(long festival, long stampId, long missionId, boolean show) {
-        ensureStamp(festival, stampId);
+    public void deleteMission(long festivalId, long stampId, long missionId) {
+        Stamp stamp = ensureStamp(festivalId, stampId);
+        Mission mission = loadMissionOrThrow(missionId);
+        missionRepository.delete(mission);
+    }
+
+    @Transactional
+    public void toggleMissionShowing(long festivalId, long stampId, long missionId, boolean show) {
+        Stamp stamp = ensureStamp(festivalId, stampId);
         Mission mission = loadMissionOrThrow(missionId);
         mission.updateMissionShow(show);
     }
@@ -58,7 +66,7 @@ public class StampMissionAdminService {
     public void updateBasicSettings(long festivalId, long stampId, final MissionBasicSettingsReqDto request) {
         Stamp stamp = ensureStamp(festivalId, stampId);
         StampMissionBasicSetting setting = loadSettingOrThrow(stampId);
-        setting.updateBasic(request.getMissionCount(), request.getDefaultDetailLayout());
+        setting.updateBasic(request.getMissionCount(), request.getMissionDetailsDesignLayout());
     }
 
     @Transactional
@@ -71,59 +79,59 @@ public class StampMissionAdminService {
 
     @Transactional
     public void updatePrize(long festivalId, long stampId, long prizeId, final MissionPrizeUpdateReqDto request) {
-        ensureStamp(festivalId, stampId);
-        StampMissionPrize prize = loadStampMissionPrizeOrThrow(prizeId);
+        Stamp stamp = ensureStamp(festivalId, stampId);
+        StampMissionPrize prize = loadStampMissionPrizeOrThrow(prizeId, stampId);
         prize.update(request.getRequiredCount(), request.getPrizeDescription());
     }
 
     @Transactional
     public void deletePrize(long festivalId, long stampId, long prizeId) {
-        ensureStamp(festivalId, stampId);
-        StampMissionPrize prize = loadStampMissionPrizeOrThrow(prizeId);
+        Stamp stamp = ensureStamp(festivalId, stampId);
+        StampMissionPrize prize = loadStampMissionPrizeOrThrow(prizeId, stampId);
         prizeRepository.delete(prize);
     }
 
     @Transactional(readOnly = true)
     public StampMissionClearImageResDto getStampMissionCompleteImage(long festivalId, long stampId, long missionId) {
-        ensureStamp(festivalId, stampId);
+        Stamp stamp = ensureStamp(festivalId, stampId);
         Mission mission = loadMissionOrThrow(missionId);
         return StampMissionClearImageResDto.from(
-                mission.isShowTitle(), mission.getClearedThumbnail(), mission.getNotClearedThumbnail());
+                mission.getShowTitle(), mission.getClearedThumbnail(), mission.getNotClearedThumbnail());
     }
 
     @Transactional
     public void updateStampMissionCompleteImage(
             long festivalId, long stampId, long missionId, final StampMissionClearImageReqDto request) {
-        ensureStamp(festivalId, stampId);
+        Stamp stamp = ensureStamp(festivalId, stampId);
         Mission mission = loadMissionOrThrow(missionId);
-        mission.updateTitleVisible(request.isShowMissionName());
+        mission.updateTitleVisible(request.isShowMissionTitle());
         mission.updateClearedImage(request.getClearedThumbnail(), request.getNotClearedThumbnail());
     }
 
     @Transactional(readOnly = true)
     public MissionDetailsTemplateResDto getMissionDetailsTemplate(long festivalId, long stampId, long missionId) {
-        ensureStamp(festivalId, stampId);
+        Stamp stamp = ensureStamp(festivalId, stampId);
         Mission mission = loadMissionOrThrow(missionId);
         MissionDetailsTemplate template = loadOrCreateMissionDetailsTemplate(mission);
         return MissionDetailsTemplateResDto.from(
-                template, mission.isShowTitle(), mission.isShowRequiredSuccessCount(), mission.getTitle());
+                template, mission.getShowTitle(), mission.getShowRequiredSuccessCount(), mission.getTitle());
     }
 
     @Transactional
     public void upsertMissionDetailsTemplate(
             long festivalId, long stampId, long missionId, final MissionDetailsTemplateReqDto request) {
-        ensureStamp(festivalId, stampId);
+        Stamp stamp = ensureStamp(festivalId, stampId);
         Mission mission = loadMissionOrThrow(missionId);
         MissionDetailsTemplate template = loadMissionDetailsTemplate(mission);
         mission.updateTitle(request.getMissionTitle());
-        mission.updateTitleVisible(request.isShowMissionName());
+        mission.updateTitleVisible(request.isShowMissionTitle());
         mission.updateRequiredSuccessCountVisible(request.isShowSuccessCount());
         template.update(
-                request.getLayout(),
+                request.getMissionDetailsDesignLayout(),
                 request.isShowExtraInfos(),
                 request.isShowButtons(),
                 request.getExtraInfoType(),
-                request.getMissionMediaSpec(),
+                request.getMediaSpec(),
                 request.getMediaUrl(),
                 request.getButtonLayout());
         template.replaceExtraInfos(request.getExtraInfos());
@@ -133,7 +141,7 @@ public class StampMissionAdminService {
     @Transactional(readOnly = true)
     public List<MissionQrDataResDto> getMissionsQrData(long festivalId, long stampId) {
         ensureStamp(festivalId, stampId);
-        List<Mission> missions = missionRepository.findAllByStampId(stampId);
+        List<Mission> missions = loadAllMissions(stampId);
         return MissionQrDataResDto.fromEntities(missions);
     }
 
@@ -159,8 +167,10 @@ public class StampMissionAdminService {
         return missionRepository.findById(missionId).orElseThrow(() -> new MissionNotFoundException(missionId));
     }
 
-    private StampMissionPrize loadStampMissionPrizeOrThrow(long prizeId) {
-        return prizeRepository.findById(prizeId).orElseThrow(() -> new MissionPrizeNotFoundException(prizeId));
+    private StampMissionPrize loadStampMissionPrizeOrThrow(long prizeId, long stampId) {
+        return prizeRepository
+                .findByIdAndStampId(prizeId, stampId)
+                .orElseThrow(() -> new MissionPrizeNotFoundException(prizeId));
     }
 
     private StampMissionBasicSetting loadSettingOrThrow(long stampId) {
@@ -177,5 +187,9 @@ public class StampMissionAdminService {
 
     private Stamp loadStampOrThrow(long id) {
         return stampRepository.findById(id).orElseThrow(() -> new StampNotFoundException(id));
+    }
+
+    private List<Mission> loadAllMissions(long stampId) {
+        return missionRepository.findAllByStampId(stampId);
     }
 }

--- a/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampTourAdminService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampTourAdminService.java
@@ -41,8 +41,7 @@ public class StampTourAdminService {
     @Transactional
     public void createStampTourByFestival(long festivalId, StampTourCreateReqDto request) {
         Festival festival = loadFestivalOrThrow(festivalId);
-        Stamp stamp = Stamp.createWith(festival, request.getTitle());
-        stamp.changeShowStamp(request.isShowStamp());
+        Stamp stamp = Stamp.createWith(festival, request.getTitle(), request.getShowStamp());
         stampRepository.save(stamp);
     }
 
@@ -80,7 +79,7 @@ public class StampTourAdminService {
     public void updateBasicSettings(long festivalId, long stampId, final StampTourBasicUpdateReqDto request) {
         Stamp stamp = ensureStamp(festivalId, stampId);
         stamp.changeBasicSettings(
-                request.isStampActivate(),
+                request.getStampActivate(),
                 request.getTitle(),
                 request.getAuthMethod(),
                 request.getPrizeReceiptAuthPassword());
@@ -152,7 +151,7 @@ public class StampTourAdminService {
     public void updateParticipateGuide(long festivalId, long stampId, StampTourParticipateGuideReqDto request) {
         ensureStamp(festivalId, stampId);
         ParticipateGuide guide = loadParticipateGuideOrThrow(stampId);
-        guide.update(request.getTemplate(), request.getMethod());
+        guide.update(request.getGuideDesignTemplate(), request.getGuideSlideMethod());
     }
 
     @Transactional

--- a/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampTourUserService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampTourUserService.java
@@ -73,11 +73,11 @@ public class StampTourUserService {
         UserMission userMission = loadUserMissionOrThrow(stampId, missionId, userUuid);
         return new MissionTemplateResDto(
                 mission.getId(),
-                mission.isShowTitle() ? mission.getTitle() : null,
+                mission.getShowTitle() ? mission.getTitle() : null,
                 template.getMediaUrl(),
                 template.getDesignLayout(),
                 userMission.getSuccessCount(),
-                mission.isShowRequiredSuccessCount() ? mission.getRequiredSuccessCount() : null,
+                mission.getShowRequiredSuccessCount() ? mission.getRequiredSuccessCount() : null,
                 MissionExtraInfoSummaryResDto.fromEntities(template.getExtraInfo()),
                 template.getButtonLayout(),
                 ButtonResDto.fromEntities(template.getButtons()));
@@ -125,7 +125,7 @@ public class StampTourUserService {
 
     private List<UserMission> filterUserMissionOnlyShowing(StampUser user) {
         return user.getUserMissions().stream()
-                .filter(um -> um.getMission() != null && um.getMission().isShow())
+                .filter(um -> um.getMission() != null && um.getMission().getShow())
                 .sorted(Comparator.comparing(um -> um.getMission().getId()))
                 .toList();
     }

--- a/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampUserAdminService.java
+++ b/src/main/java/com/halo/eventer/domain/stamp/service/v2/StampUserAdminService.java
@@ -24,7 +24,6 @@ import com.halo.eventer.domain.stamp.repository.StampRepository;
 import com.halo.eventer.domain.stamp.repository.StampUserRepository;
 import com.halo.eventer.global.common.page.PageInfo;
 import com.halo.eventer.global.common.page.PagedResponse;
-import com.halo.eventer.global.utils.EncryptService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,7 +34,6 @@ public class StampUserAdminService {
 
     private final StampRepository stampRepository;
     private final StampUserRepository stampUserRepository;
-    private final EncryptService encryptService;
 
     @Transactional(readOnly = true)
     public PagedResponse<StampUserSummaryResDto> getStampUsers(
@@ -55,7 +53,7 @@ public class StampUserAdminService {
         List<UserMissionStatusResDto> missions = stampUser.getUserMissions().stream()
                 .sorted(Comparator.comparing(um -> um.getMission().getId()))
                 .map(um -> new UserMissionStatusResDto(
-                        um.getId(), um.getMission().getId(), um.getMission().getTitle(), um.isComplete()))
+                        um.getId(), um.getMission().getId(), um.getMission().getTitle(), um.getIsComplete()))
                 .toList();
 
         return new StampUserDetailResDto(
@@ -63,7 +61,7 @@ public class StampUserAdminService {
                 stampUser.getName(),
                 stampUser.getPhone(),
                 stampUser.getUuid(),
-                stampUser.isFinished(),
+                stampUser.getIsFinished(),
                 missions,
                 stampUser.getExtraText(),
                 stampUser.getParticipantCount());
@@ -99,7 +97,7 @@ public class StampUserAdminService {
 
     private void syncUserFinishedFlag(StampUser su) {
         long completed =
-                su.getUserMissions().stream().filter(UserMission::isComplete).count();
+                su.getUserMissions().stream().filter(UserMission::getIsComplete).count();
         boolean finished = completed >= su.getStamp().getFinishCount();
         su.markAsFinished(finished);
     }
@@ -136,7 +134,7 @@ public class StampUserAdminService {
         List<UserMissionStatusResDto> missions = su.getUserMissions().stream()
                 .sorted(Comparator.comparing(um -> um.getMission().getId()))
                 .map(um -> new UserMissionStatusResDto(
-                        um.getId(), um.getMission().getId(), um.getMission().getTitle(), um.isComplete()))
+                        um.getId(), um.getMission().getId(), um.getMission().getTitle(), um.getIsComplete()))
                 .toList();
 
         return new StampUserDetailResDto(
@@ -144,7 +142,7 @@ public class StampUserAdminService {
                 su.getName(),
                 su.getPhone(),
                 su.getUuid(),
-                su.isFinished(),
+                su.getIsFinished(),
                 missions,
                 su.getExtraText(),
                 su.getParticipantCount());

--- a/src/main/java/com/halo/eventer/global/config/security/CorsConfig.java
+++ b/src/main/java/com/halo/eventer/global/config/security/CorsConfig.java
@@ -24,7 +24,10 @@ public class CorsConfig {
             "https://adelante.wabauniv.com",
             "http://m.localhost:3000",
             "https://firefestivaljeju.com",
-            "https://m.firefestivaljeju.com");
+            "https://m.firefestivaljeju.com",
+            "https://stamp.jejufestival.festiv.kr",
+            "https://parking.jejufestival.festiv.kr",
+            "https://business.festiv.kr");
 
     @Bean
     public CorsConfigurationSource customCorsConfigurationSource() {

--- a/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingLotDoc.java
+++ b/src/test/java/com/halo/eventer/domain/parking/api_docs/ParkingLotDoc.java
@@ -192,14 +192,14 @@ public class ParkingLotDoc {
                 resource(ResourceSnippetParameters.builder()
                         .tag(TAG)
                         .summary("주차장 혼잡도 변경")
-                        .description("주차장의 혼잡도 레벨을 변경합니다. (예: LOW/MEDIUM/HIGH)")
+                        .description("주차장의 혼잡도 레벨을 변경합니다. (예: LOW/MEDIUM/HIGH/FULL/CLOSED)")
                         .requestSchema(Schema.schema("CongestionLevelReqDto"))
                         .pathParameters(parameterWithName("id")
                                 .description("주차장 id")
                                 .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxMin2(1)))))
                         .requestFields(fieldWithPath("congestionLevel")
                                 .type(JsonFieldType.STRING)
-                                .description("혼잡도 레벨 (LOW/MEDIUM/HIGH)")
+                                .description("혼잡도 레벨 (LOW/MEDIUM/HIGH/FULL/CLOSED)")
                                 .attributes(key("validationConstraints").value(List.of(ApiConstraint.JavaxNotNull()))))
                         .build()));
     }

--- a/src/test/java/com/halo/eventer/domain/stamp/entity/StampTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/entity/StampTest.java
@@ -33,7 +33,7 @@ public class StampTest {
     void 스탬프_생성() {
         // given & when & then
         assertThat(stamp.getFestival()).isEqualTo(festival);
-        assertThat(stamp.isActive()).isTrue();
+        assertThat(stamp.getActive()).isTrue();
         assertThat(stamp.getFinishCount()).isZero();
     }
 
@@ -43,7 +43,7 @@ public class StampTest {
         stamp.switchActivation();
 
         // then
-        assertThat(stamp.isActive()).isFalse();
+        assertThat(stamp.getActive()).isFalse();
     }
 
     @Test
@@ -53,7 +53,7 @@ public class StampTest {
         stamp.switchActivation();
 
         // then
-        assertThat(stamp.isActive()).isTrue();
+        assertThat(stamp.getActive()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/halo/eventer/domain/stamp/entity/StampUserTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/entity/StampUserTest.java
@@ -39,7 +39,7 @@ public class StampUserTest {
     @Test
     void 완료_마킹() {
         stampUser.markAsFinished(true);
-        assertThat(stampUser.isFinished()).isTrue();
+        assertThat(stampUser.getIsFinished()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/halo/eventer/domain/stamp/entity/UserMissionTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/entity/UserMissionTest.java
@@ -41,7 +41,7 @@ public class UserMissionTest {
         userMission.markAsComplete();
 
         // then
-        assertThat(userMission.isComplete()).isTrue();
+        assertThat(userMission.getIsComplete()).isTrue();
     }
 
     @Test
@@ -49,12 +49,12 @@ public class UserMissionTest {
         userMission = UserMission.create(mission, stampUser);
         userMission.markAsComplete();
 
-        boolean before = userMission.isComplete();
+        boolean before = userMission.getIsComplete();
 
         // when
         userMission.markAsComplete();
 
         // then
-        assertThat(userMission.isComplete()).isEqualTo(before).isTrue();
+        assertThat(userMission.getIsComplete()).isEqualTo(before).isTrue();
     }
 }

--- a/src/test/java/com/halo/eventer/domain/stamp/repository/StampRepositoryTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/repository/StampRepositoryTest.java
@@ -32,7 +32,7 @@ public class StampRepositoryTest {
     @BeforeEach
     void setUp() {
         festival = Festival.from(FestivalFixture.축제_생성용_DTO());
-        stamp = Stamp.createWith(festival, "title");
+        stamp = Stamp.createWith(festival, "title", true);
         festivalRepository.save(festival);
         stampRepository.save(stamp);
     }

--- a/src/test/java/com/halo/eventer/domain/stamp/repository/StampUserRepositoryTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/repository/StampUserRepositoryTest.java
@@ -35,7 +35,7 @@ public class StampUserRepositoryTest {
     void setUp() {
         festival = 축제_엔티티();
         festivalRepository.save(festival);
-        stamp = Stamp.createWith(festival, "title");
+        stamp = Stamp.createWith(festival, "title", true);
         stampRepository.save(stamp);
         stampUser = 스탬프유저1_생성();
         stampUser.addStamp(stamp);

--- a/src/test/java/com/halo/eventer/domain/stamp/service/StampServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/service/StampServiceTest.java
@@ -81,7 +81,7 @@ public class StampServiceTest {
 
         // then
         assertThat(results).hasSize(1);
-        assertThat(result.isStampOn()).isEqualTo(stamp1.isActive());
+        assertThat(result.isStampOn()).isEqualTo(stamp1.getActive());
         assertThat(result.getStampId()).isEqualTo(stamp1.getId());
         assertThat(result.getStampFinishCnt()).isEqualTo(stamp1.getFinishCount());
     }
@@ -98,7 +98,7 @@ public class StampServiceTest {
 
         // then
         assertThat(results).hasSize(3);
-        assertThat(results.get(0).isStampOn()).isEqualTo(stamp1.isActive());
+        assertThat(results.get(0).isStampOn()).isEqualTo(stamp1.getActive());
         assertThat(results.get(0).getStampId()).isEqualTo(stamp1.getId());
         assertThat(results.get(0).getStampFinishCnt()).isEqualTo(stamp1.getFinishCount());
     }
@@ -126,7 +126,7 @@ public class StampServiceTest {
 
         // then
         assertThat(results).hasSize(3);
-        assertThat(result.isStampOn()).isEqualTo(stamp1.isActive());
+        assertThat(result.isStampOn()).isEqualTo(stamp1.getActive());
         assertThat(result.getStampId()).isEqualTo(stamp1.getId());
         assertThat(result.getStampFinishCnt()).isEqualTo(stamp1.getFinishCount());
     }
@@ -145,11 +145,11 @@ public class StampServiceTest {
     void 스탬프_상태_변경_성공() {
         // given
         given(stampRepository.findById(anyLong())).willReturn(Optional.ofNullable(stamp1));
-        boolean before = stamp1.isActive();
+        boolean before = stamp1.getActive();
 
         // when
         stampService.updateStampOn(스탬프1_ID);
-        boolean after = stamp1.isActive();
+        boolean after = stamp1.getActive();
 
         // then
         assertThat(after).isEqualTo(!before);

--- a/src/test/java/com/halo/eventer/domain/stamp/service/StampUserServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/service/StampUserServiceTest.java
@@ -214,7 +214,7 @@ public class StampUserServiceTest {
 
         // then
         assertThat(result).isNotNull();
-        assertThat(result.isFinished()).isEqualTo(stampUser.isFinished());
+        assertThat(result.isFinished()).isEqualTo(stampUser.getIsFinished());
     }
 
     @Test
@@ -253,7 +253,7 @@ public class StampUserServiceTest {
         stampUserService.updateUserMission("", 1L);
 
         // then
-        assertThat(userMission1.isComplete()).isEqualTo(true);
+        assertThat(userMission1.getIsComplete()).isEqualTo(true);
     }
 
     @Test

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampMissionAdminDocs.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampMissionAdminDocs.java
@@ -26,7 +26,24 @@ public class StampMissionAdminDocs {
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
                                 parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
-                        .requestFields(fieldWithPath("name").type(STRING).description("미션 이름"))
+                        .requestFields(
+                                fieldWithPath("title").type(STRING).description("미션 이름"),
+                                fieldWithPath("showMission").type(BOOLEAN).description("미션 공개 여부"))
+                        .build()));
+    }
+
+    public static RestDocumentationResultHandler deleteMission() {
+        return document(
+                "v2-mission-delete",
+                resource(builder()
+                        .tag(TAG)
+                        .summary("미션 삭제")
+                        .description("스탬프투어에서 특정 미션을 삭제합니다.")
+                        .pathParameters(
+                                parameterWithName("festivalId").description("축제 ID (>=1)"),
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"),
+                                parameterWithName("missionId").description("미션 ID (>=1)"))
+                        .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .build()));
     }
 
@@ -41,8 +58,24 @@ public class StampMissionAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("[].missionId").type(NUMBER).description("미션 ID"),
-                                fieldWithPath("[].title").type(STRING).description("제목"))
+                                fieldWithPath("limitMissionCount").type(NUMBER).description("최대 미션 개수 제한"),
+                                fieldWithPath("missionList").type(ARRAY).description("미션 목록(비어있을 수 있음)"),
+                                fieldWithPath("missionList[].missionId")
+                                        .type(NUMBER)
+                                        .optional()
+                                        .description("미션 ID"),
+                                fieldWithPath("missionList[].title")
+                                        .type(STRING)
+                                        .optional()
+                                        .description("제목"),
+                                fieldWithPath("missionList[].showMission")
+                                        .type(BOOLEAN)
+                                        .optional()
+                                        .description("미션 공개 여부"),
+                                fieldWithPath("missionList[].showMissionTitle")
+                                        .type(BOOLEAN)
+                                        .optional()
+                                        .description("미션 제목 공개 여부"))
                         .build()));
     }
 
@@ -58,15 +91,17 @@ public class StampMissionAdminDocs {
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
                                 fieldWithPath("missionCount").type(NUMBER).description("미션 총 개수"),
-                                fieldWithPath("layout").type(STRING).description("기본 상세 레이아웃"),
-                                fieldWithPath("prizes").type(ARRAY).description("리워드(상품) 목록"),
+                                fieldWithPath("missionDetailsDesignLayout")
+                                        .type(STRING)
+                                        .description("기본 상세 레이아웃"),
+                                fieldWithPath("prizes").type(ARRAY).optional().description("경품 목록"),
                                 fieldWithPath("prizes[].id").type(NUMBER).description("상품 ID"),
                                 fieldWithPath("prizes[].requiredCount")
                                         .type(NUMBER)
                                         .description("필요 스탬프 수"),
-                                fieldWithPath("prizes[].description")
+                                fieldWithPath("prizes[].prizeDescription")
                                         .type(STRING)
-                                        .description("상품 설명"))
+                                        .description("경품 설명"))
                         .build()));
     }
 
@@ -82,9 +117,9 @@ public class StampMissionAdminDocs {
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(
                                 fieldWithPath("missionCount").type(NUMBER).description("미션 총 개수(2~16)"),
-                                fieldWithPath("defaultDetailLayout")
+                                fieldWithPath("missionDetailsDesignLayout")
                                         .type(STRING)
-                                        .description("기본 상세 레이아웃(enum)"))
+                                        .description("기본 상세 레이아웃(   CARD, IMAGE_TOP, IMAGE_SIDE, TEXT_ONLY)"))
                         .build()));
     }
 
@@ -165,12 +200,15 @@ public class StampMissionAdminDocs {
                                 parameterWithName("missionId").description("미션 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("templateId").type(NUMBER).description("템플릿 ID"),
-                                fieldWithPath("layout").type(STRING).description("디자인 레이아웃"),
-                                fieldWithPath("showMissionName").type(BOOLEAN).description("제목 표시"),
-                                fieldWithPath("missionName").type(STRING).description("미션 제목"),
+                                fieldWithPath("missionDetailsDesignLayout")
+                                        .type(STRING)
+                                        .description("디자인 레이아웃"),
+                                fieldWithPath("showMissionTitle").type(BOOLEAN).description("제목 표시"),
+                                fieldWithPath("missionTitle").type(STRING).description("미션 제목"),
                                 fieldWithPath("showSuccessCount").type(BOOLEAN).description("성공횟수 표시"),
-                                fieldWithPath("mediaSpec").type(STRING).description("미디어 스펙"),
+                                fieldWithPath("mediaSpec")
+                                        .type(STRING)
+                                        .description("미디어 스펙 (NONE, ONE_TO_ONE, SIXTEEN_TO_NINE, RATIO_NO_CHANGE)"),
                                 fieldWithPath("mediaUrl")
                                         .type(STRING)
                                         .optional()
@@ -179,7 +217,7 @@ public class StampMissionAdminDocs {
                                 fieldWithPath("extraInfoType")
                                         .type(STRING)
                                         .optional()
-                                        .description("추가정보 레이아웃"),
+                                        .description("추가정보 레이아웃 (LIST)"),
                                 fieldWithPath("extraInfos").type(ARRAY).description("추가정보 요약 목록"),
                                 fieldWithPath("extraInfos[].extraInfoId")
                                         .type(NUMBER)
@@ -193,7 +231,9 @@ public class StampMissionAdminDocs {
                                         .optional()
                                         .description("본문"),
                                 fieldWithPath("showButtons").type(BOOLEAN).description("버튼 표시"),
-                                fieldWithPath("buttonLayout").type(STRING).description("버튼 레이아웃"),
+                                fieldWithPath("buttonLayout")
+                                        .type(STRING)
+                                        .description("버튼 레이아웃 (ONE,TWO_ASYM, TWO_SYM, TWO_UP_DOWN, NONE)"),
                                 fieldWithPath("buttons").type(ARRAY).description("버튼 목록"),
                                 fieldWithPath("buttons[].sequenceIndex")
                                         .type(NUMBER)
@@ -203,7 +243,9 @@ public class StampMissionAdminDocs {
                                         .type(STRING)
                                         .optional()
                                         .description("아이콘 URL"),
-                                fieldWithPath("buttons[].action").type(STRING).description("동작"),
+                                fieldWithPath("buttons[].action")
+                                        .type(STRING)
+                                        .description("동작 ( QR_CAMERA, NFC_SCAN, OPEN_URL, OPEN_NEW_PAGE, OPEN_POPUP)"),
                                 fieldWithPath("buttons[].targetUrl")
                                         .type(STRING)
                                         .optional()
@@ -224,13 +266,15 @@ public class StampMissionAdminDocs {
                                 parameterWithName("missionId").description("미션 ID (>=1)"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(
-                                fieldWithPath("layout").type(STRING).description("디자인 레이아웃"),
+                                fieldWithPath("missionDetailsDesignLayout")
+                                        .type(STRING)
+                                        .description("디자인 레이아웃"),
                                 fieldWithPath("missionTitle").type(STRING).description("미션 제목"),
-                                fieldWithPath("showMissionName").type(BOOLEAN).description("제목 표시"),
+                                fieldWithPath("showMissionTitle").type(BOOLEAN).description("제목 표시"),
                                 fieldWithPath("showSuccessCount").type(BOOLEAN).description("성공횟수 표시"),
                                 fieldWithPath("showExtraInfos").type(BOOLEAN).description("추가정보 표시"),
                                 fieldWithPath("showButtons").type(BOOLEAN).description("버튼 표시"),
-                                fieldWithPath("missionMediaSpec").type(STRING).description("미디어 스펙"),
+                                fieldWithPath("mediaSpec").type(STRING).description("미디어 스펙"),
                                 fieldWithPath("mediaUrl")
                                         .type(STRING)
                                         .optional()
@@ -256,7 +300,7 @@ public class StampMissionAdminDocs {
                                 fieldWithPath("buttons[].sequenceIndex")
                                         .type(NUMBER)
                                         .description("순서(0-base)"),
-                                fieldWithPath("buttons[].iconImg")
+                                fieldWithPath("buttons[].iconImgUrl")
                                         .type(STRING)
                                         .optional()
                                         .description("아이콘 이미지"),
@@ -282,7 +326,7 @@ public class StampMissionAdminDocs {
                                 parameterWithName("missionId").description("미션 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("showMissionName").type(BOOLEAN).description("제목 표시"),
+                                fieldWithPath("showMissionTitle").type(BOOLEAN).description("제목 표시"),
                                 fieldWithPath("clearedThumbnail")
                                         .type(STRING)
                                         .optional()

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampTourAdminDocs.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampTourAdminDocs.java
@@ -38,7 +38,7 @@ public class StampTourAdminDocs {
                         .pathParameters(parameterWithName("festivalId").description("축제 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("[].stampTourId").type(NUMBER).description("ID"),
+                                fieldWithPath("[].stampId").type(NUMBER).description("스탬프 ID"),
                                 fieldWithPath("[].title").type(STRING).description("제목"),
                                 fieldWithPath("[].showStamp").type(BOOLEAN).description("목록 노출 여부"))
                         .build()));
@@ -101,13 +101,15 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("stampTourId").type(NUMBER).description("ID"),
+                                fieldWithPath("stampId").type(NUMBER).description("ID"),
                                 fieldWithPath("stampActive").type(BOOLEAN).description("활성화 여부"),
                                 fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("authMethod").type(STRING).description("인증 방식"),
+                                fieldWithPath("authMethod")
+                                        .type(STRING)
+                                        .description("인증 방식 (TAG_SCAN, USER_CODE_PRESENT)"),
                                 fieldWithPath("prizeReceiptAuthPassword")
                                         .type(STRING)
-                                        .description("수령 비밀번호"))
+                                        .description("경품 수령 관리자 비밀번호"))
                         .build()));
     }
 
@@ -122,12 +124,14 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(
-                                fieldWithPath("isStampActivate").type(BOOLEAN).description("활성화"),
+                                fieldWithPath("stampActivate").type(BOOLEAN).description("활성화"),
                                 fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("authMethod").type(STRING).description("인증 방식"),
+                                fieldWithPath("authMethod")
+                                        .type(STRING)
+                                        .description("인증 방식 (TAG_SCAN, USER_CODE_PRESENT)"),
                                 fieldWithPath("prizeReceiptAuthPassword")
                                         .type(STRING)
-                                        .description("수령 비밀번호"))
+                                        .description("경품 수령 관리자 비밀번호"))
                         .build()));
     }
 
@@ -180,7 +184,9 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("designTemplate").type(STRING).description("디자인 템플릿"),
+                                fieldWithPath("landingPageDesignTemplate")
+                                        .type(STRING)
+                                        .description("랜딩 페이지 디자인 템플릿 (NONE)"),
                                 fieldWithPath("backgroundImgUrl")
                                         .type(STRING)
                                         .optional()
@@ -193,8 +199,14 @@ public class StampTourAdminDocs {
                                         .type(STRING)
                                         .optional()
                                         .description("설명"),
-                                fieldWithPath("buttonLayout").type(STRING).description("버튼 배치"),
-                                fieldWithPath("buttons").type(ARRAY).description("버튼 목록"),
+                                fieldWithPath("buttonLayout")
+                                        .type(STRING)
+                                        .description(
+                                                "버튼 배치 방법(ONE(1개), TWO_ASYM(2개 비대칭), TWO_SYM(2개 대칭), TWO_UP_DOWN(2개 상하), NONE(없음))"),
+                                fieldWithPath("buttons")
+                                        .type(ARRAY)
+                                        .optional()
+                                        .description("버튼 목록, buttonLayout이 NONE인 경우 빈 리스트 반환"),
                                 fieldWithPath("buttons[].sequenceIndex")
                                         .type(NUMBER)
                                         .description("순서"),
@@ -203,11 +215,13 @@ public class StampTourAdminDocs {
                                         .type(STRING)
                                         .optional()
                                         .description("아이콘 URL"),
-                                fieldWithPath("buttons[].action").type(STRING).description("동작"),
+                                fieldWithPath("buttons[].action")
+                                        .type(STRING)
+                                        .description("버튼 기능 (QR_CAMERA, NFC_SCAN,OPEN_URL,OPEN_NEW_PAGE, OPEN_POPUP)"),
                                 fieldWithPath("buttons[].targetUrl")
                                         .type(STRING)
                                         .optional()
-                                        .description("URL"))
+                                        .description("URL, QR 카메라 혹은 NFC 일때는 null"))
                         .build()));
     }
 
@@ -222,22 +236,34 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(
-                                fieldWithPath("designTemplate").type(STRING).description("랜딩 템플릿"),
+                                fieldWithPath("landingPageDesignTemplate")
+                                        .type(STRING)
+                                        .description("랜딩 페이지 디자인 템플릿 (NONE)"),
                                 fieldWithPath("backgroundImgUrl").type(STRING).description("배경 이미지 URL"),
                                 fieldWithPath("iconImgUrl").type(STRING).description("아이콘 이미지 URL"),
                                 fieldWithPath("description").type(STRING).description("설명"),
-                                fieldWithPath("buttonLayout").type(STRING).description("버튼 레이아웃"),
-                                fieldWithPath("buttons").type(ARRAY).optional().description("버튼 목록"),
+                                fieldWithPath("buttonLayout")
+                                        .type(STRING)
+                                        .description(
+                                                "버튼 배치 방법(ONE(1개), TWO_ASYM(2개 비대칭), TWO_SYM(2개 대칭), TWO_UP_DOWN(2개 상하), NONE(없음))"),
+                                fieldWithPath("buttons")
+                                        .type(ARRAY)
+                                        .optional()
+                                        .description("버튼 목록, buttonLayout이 NONE인 경우 빈 리스트로 요청"),
                                 fieldWithPath("buttons[].sequenceIndex")
                                         .type(NUMBER)
                                         .description("순서"),
-                                fieldWithPath("buttons[].iconImg").type(STRING).description("아이콘 (요청 필드)"),
+                                fieldWithPath("buttons[].iconImgUrl")
+                                        .type(STRING)
+                                        .description("아이콘"),
                                 fieldWithPath("buttons[].content").type(STRING).description("라벨"),
-                                fieldWithPath("buttons[].action").type(STRING).description("동작"),
+                                fieldWithPath("buttons[].action")
+                                        .type(STRING)
+                                        .description("버튼 기능 (QR_CAMERA, NFC_SCAN,OPEN_URL,OPEN_NEW_PAGE, OPEN_POPUP)"),
                                 fieldWithPath("buttons[].targetUrl")
                                         .type(STRING)
                                         .optional()
-                                        .description("URL"))
+                                        .description("URL, QR 카메라 혹은 NFC 일때는 null"))
                         .build()));
     }
 
@@ -253,13 +279,32 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("designTemplate").type(STRING).description("디자인 템플릿"),
-                                fieldWithPath("backgroundImg")
+                                fieldWithPath("mainPageDesignTemplate")
+                                        .type(STRING)
+                                        .description("메인 페이지 디자인 템플릿(GRID_Nx2, GRID_Nx3)"),
+                                fieldWithPath("backgroundImgUrl")
                                         .type(STRING)
                                         .optional()
                                         .description("배경 이미지"),
-                                fieldWithPath("buttonLayout").type(STRING).description("버튼 배치"),
-                                fieldWithPath("buttons").type(ARRAY).description("버튼 목록"))
+                                fieldWithPath("buttonLayout")
+                                        .type(STRING)
+                                        .description(
+                                                "버튼 배치 방법(ONE(1개), TWO_ASYM(2개 비대칭), TWO_SYM(2개 대칭), TWO_UP_DOWN(2개 상하), NONE(없음))"),
+                                fieldWithPath("buttons").type(ARRAY).optional().description("버튼 목록"),
+                                fieldWithPath("buttons[].sequenceIndex")
+                                        .type(NUMBER)
+                                        .description("순서"),
+                                fieldWithPath("buttons[].iconImgUrl")
+                                        .type(STRING)
+                                        .description("아이콘 (요청 필드)"),
+                                fieldWithPath("buttons[].content").type(STRING).description("라벨"),
+                                fieldWithPath("buttons[].action")
+                                        .type(STRING)
+                                        .description("버튼 기능 (QR_CAMERA, NFC_SCAN, OPEN_URL,OPEN_NEW_PAGE, OPEN_POPUP)"),
+                                fieldWithPath("buttons[].targetUrl")
+                                        .type(STRING)
+                                        .optional()
+                                        .description("URL, QR 카메라 혹은 NFC 일때는 null"))
                         .build()));
     }
 
@@ -274,10 +319,29 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(
-                                fieldWithPath("designTemplate").type(STRING).description("디자인 템플릿"),
+                                fieldWithPath("mainPageDesignTemplate")
+                                        .type(STRING)
+                                        .description("메인 페이지 디자인 템플릿(GRID_Nx2, GRID_Nx3)"),
                                 fieldWithPath("backgroundImgUrl").type(STRING).description("배경 이미지 URL"),
-                                fieldWithPath("buttonLayout").type(STRING).description("버튼 레이아웃"),
-                                fieldWithPath("buttons").type(ARRAY).optional().description("버튼 목록"))
+                                fieldWithPath("buttonLayout")
+                                        .type(STRING)
+                                        .description(
+                                                "버튼 배치 방법(ONE(1개), TWO_ASYM(2개 비대칭), TWO_SYM(2개 대칭), TWO_UP_DOWN(2개 상하), NONE(없음))"),
+                                fieldWithPath("buttons").type(ARRAY).optional().description("버튼 목록"),
+                                fieldWithPath("buttons[].sequenceIndex")
+                                        .type(NUMBER)
+                                        .description("순서"),
+                                fieldWithPath("buttons[].iconImgUrl")
+                                        .type(STRING)
+                                        .description("아이콘"),
+                                fieldWithPath("buttons[].content").type(STRING).description("라벨"),
+                                fieldWithPath("buttons[].action")
+                                        .type(STRING)
+                                        .description("버튼 기능 (QR_CAMERA, NFC_SCAN,OPEN_URL,OPEN_NEW_PAGE, OPEN_POPUP)"),
+                                fieldWithPath("buttons[].targetUrl")
+                                        .type(STRING)
+                                        .optional()
+                                        .description("URL, QR 카메라 혹은 NFC 일때는 null"))
                         .build()));
     }
 
@@ -293,11 +357,14 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
-                                fieldWithPath("participateGuideId").type(NUMBER).description("가이드 ID"),
                                 fieldWithPath("guideDesignTemplate")
                                         .type(STRING)
-                                        .description("디자인 템플릿"),
-                                fieldWithPath("guideSlideMethod").type(STRING).description("슬라이드 방식"),
+                                        .description("참여 방법 안내 디자인 템플릿 (FULL, NON_FULL)"),
+                                fieldWithPath("guideSlideMethod").type(STRING).description("슬라이드 방식 (SLIDE)"),
+                                fieldWithPath("participateGuidePages")
+                                        .type(ARRAY)
+                                        .optional()
+                                        .description("참여 방법 페이지들 간략 요소 (페이지 없으면 빈 리스트 반환)"),
                                 fieldWithPath("participateGuidePages[].pageId")
                                         .type(NUMBER)
                                         .description("페이지 ID"),
@@ -321,8 +388,10 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(
-                                fieldWithPath("template").type(STRING).description("디자인 템플릿"),
-                                fieldWithPath("method").type(STRING).description("슬라이드 방식"))
+                                fieldWithPath("guideDesignTemplate")
+                                        .type(STRING)
+                                        .description("참여 방법 안내 디자인 템플릿 (FULL, NON_FULL)"),
+                                fieldWithPath("guideSlideMethod").type(STRING).description("슬라이드 방식 (SLIDE)"))
                         .build()));
     }
 
@@ -358,9 +427,10 @@ public class StampTourAdminDocs {
                                 parameterWithName("stampId").description("스탬프투어 ID"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(
-                                fieldWithPath("guideId").type(NUMBER).description("가이드 ID"),
                                 fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("mediaSpec").type(STRING).description("미디어 스펙"),
+                                fieldWithPath("mediaSpec")
+                                        .type(STRING)
+                                        .description("미디어 스펙 ( NONE, ONE_TO_ONE, SIXTEEN_TO_NINE, RATIO_NO_CHANGE )"),
                                 fieldWithPath("mediaUrl")
                                         .type(STRING)
                                         .optional()
@@ -385,7 +455,9 @@ public class StampTourAdminDocs {
                         .responseFields(
                                 fieldWithPath("pageId").type(NUMBER).description("페이지 ID"),
                                 fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("mediaSpec").type(STRING).description("미디어 스펙"),
+                                fieldWithPath("mediaSpec")
+                                        .type(STRING)
+                                        .description("미디어 스펙( NONE, ONE_TO_ONE, SIXTEEN_TO_NINE, RATIO_NO_CHANGE )"),
                                 fieldWithPath("mediaUrl")
                                         .type(STRING)
                                         .optional()
@@ -410,7 +482,9 @@ public class StampTourAdminDocs {
                         .requestFields(
                                 fieldWithPath("guideId").type(NUMBER).description("가이드 ID"),
                                 fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("mediaSpec").type(STRING).description("미디어 스펙"),
+                                fieldWithPath("mediaSpec")
+                                        .type(STRING)
+                                        .description("미디어 스펙 ( NONE, ONE_TO_ONE, SIXTEEN_TO_NINE, RATIO_NO_CHANGE )"),
                                 fieldWithPath("mediaUrl")
                                         .type(STRING)
                                         .optional()

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampTourTemplateDocs.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampTourTemplateDocs.java
@@ -21,7 +21,7 @@ public class StampTourTemplateDocs {
                         .summary("스탬프투어 목록 조회(템플릿)")
                         .pathParameters(parameterWithName("festivalId").description("축제 ID (>=1)"))
                         .responseFields(
-                                fieldWithPath("[].stampTourId").type(NUMBER).description("스탬프투어 ID"),
+                                fieldWithPath("[].stampId").type(NUMBER).description("스탬프투어 ID"),
                                 fieldWithPath("[].title").type(STRING).description("제목"),
                                 fieldWithPath("[].showStamp").type(BOOLEAN).description("목록 노출 여부"))
                         .build()));
@@ -35,7 +35,7 @@ public class StampTourTemplateDocs {
                         .summary("회원가입 템플릿 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .responseFields(fieldWithPath("joinVerificationMethod")
                                 .type(STRING)
                                 .description("참여 인증 방식(enum: NONE, SMS, PASS)"))
@@ -50,9 +50,11 @@ public class StampTourTemplateDocs {
                         .summary("랜딩 페이지 템플릿 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .responseFields(
-                                fieldWithPath("designTemplate").type(STRING).description("랜딩 디자인 템플릿"),
+                                fieldWithPath("landingPageDesignTemplate")
+                                        .type(STRING)
+                                        .description("랜딩 디자인 템플릿"),
                                 fieldWithPath("iconImgUrl").type(STRING).description("아이콘 이미지 URL"),
                                 fieldWithPath("backgroundImgUrl").type(STRING).description("배경 이미지 URL"),
                                 fieldWithPath("description").type(STRING).description("설명"),
@@ -81,7 +83,7 @@ public class StampTourTemplateDocs {
                         .summary("참여 인증 템플릿 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .responseFields(
                                 fieldWithPath("method").type(STRING).description("참여 인증 방식(enum: NONE, SMS, PASS)"))
                         .build()));
@@ -95,7 +97,7 @@ public class StampTourTemplateDocs {
                         .summary("스탬프 인증 방식 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .responseFields(fieldWithPath("authMethod")
                                 .type(STRING)
                                 .description("인증 방식(enum: TAG_SCAN, USER_CODE_PRESENT)"))
@@ -110,10 +112,12 @@ public class StampTourTemplateDocs {
                         .summary("메인 페이지 템플릿 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .responseFields(
-                                fieldWithPath("designTemplate").type(STRING).description("메인 디자인 템플릿"),
-                                fieldWithPath("backgroundImg").type(STRING).description("배경 이미지"),
+                                fieldWithPath("mainPageDesignTemplate")
+                                        .type(STRING)
+                                        .description("메인 디자인 템플릿"),
+                                fieldWithPath("backgroundImgUrl").type(STRING).description("배경 이미지"),
                                 fieldWithPath("buttonLayout").type(STRING).description("버튼 레이아웃"),
                                 fieldWithPath("buttons").type(ARRAY).description("버튼 목록"),
                                 fieldWithPath("buttons[].sequenceIndex")
@@ -140,7 +144,7 @@ public class StampTourTemplateDocs {
                         .summary("안내사항 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .responseFields(
                                 fieldWithPath("cautionContent").type(STRING).description("주의사항"),
                                 fieldWithPath("personalInformationContent")
@@ -157,7 +161,7 @@ public class StampTourTemplateDocs {
                         .summary("참여가이드 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .responseFields(
                                 fieldWithPath("participateGuideId").type(NUMBER).description("가이드 ID"),
                                 fieldWithPath("guideDesignTemplate")

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampTourUserDocs.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/api_docs/StampTourUserDocs.java
@@ -23,7 +23,7 @@ public class StampTourUserDocs {
                         .summary("스탬프투어 사용자 회원가입")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .requestFields(
                                 fieldWithPath("name").type(STRING).description("이름"),
                                 fieldWithPath("phone").type(STRING).description("전화번호"),
@@ -41,7 +41,7 @@ public class StampTourUserDocs {
                         .summary("스탬프투어 사용자 로그인")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .requestFields(
                                 fieldWithPath("name").type(STRING).description("이름"),
                                 fieldWithPath("phone").type(STRING).description("전화번호"))
@@ -58,7 +58,7 @@ public class StampTourUserDocs {
                         .summary("사용자 미션 보드 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
                                 fieldWithPath("completedCount").type(NUMBER).description("완료한 미션 수"),
@@ -87,7 +87,7 @@ public class StampTourUserDocs {
                         .summary("사용자 미션 상세 템플릿 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"),
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"),
                                 parameterWithName("missionId").description("미션 ID (>=1)"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
@@ -147,7 +147,7 @@ public class StampTourUserDocs {
                         .summary("미션 완료 QR 인증")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .requestFields(fieldWithPath("missionId").type(NUMBER).description("미션 ID"))
                         .build()));
@@ -162,7 +162,7 @@ public class StampTourUserDocs {
                         .summary("경품 수령용 QR 정보 조회")
                         .pathParameters(
                                 parameterWithName("festivalId").description("축제 ID (>=1)"),
-                                parameterWithName("stampTourId").description("스탬프투어 ID (>=1)"))
+                                parameterWithName("stampId").description("스탬프투어 ID (>=1)"))
                         .requestHeaders(headerWithName("Authorization").description("JWT Access 토큰"))
                         .responseFields(
                                 fieldWithPath("userName").type(STRING).description("이름"),

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/controller/StampTourAdminControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/controller/StampTourAdminControllerTest.java
@@ -1,5 +1,7 @@
 package com.halo.eventer.domain.stamp.v2.controller;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -106,7 +108,8 @@ public class StampTourAdminControllerTest {
             mockMvc.perform(get("/api/v2/admin/festivals/{festivalId}/stamp-tours", 축제_ID)
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$[0].stampTourId").value(10L))
+                    .andExpect(jsonPath("$[0].stampId").value(10L))
+                    .andExpect(jsonPath("$[1].stampId").value(11L))
                     .andDo(StampTourAdminDocs.listStampTours());
         }
 
@@ -133,6 +136,14 @@ public class StampTourAdminControllerTest {
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
                     .andExpect(status().isOk())
                     .andDo(StampTourAdminDocs.deleteStampTour());
+        }
+
+        @Test
+        void 삭제_실패_권한없음() throws Exception {
+            mockMvc.perform(delete("/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}", 축제_ID, 스탬프_ID)
+                            .header(HttpHeaders.AUTHORIZATION, AUTH))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-delete-unauthorized"));
         }
     }
 
@@ -240,7 +251,7 @@ public class StampTourAdminControllerTest {
                                     스탬프_ID)
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.stampTourId").value(스탬프_ID))
+                    .andExpect(jsonPath("$.stampId").value(스탬프_ID))
                     .andDo(StampTourAdminDocs.getBasic());
         }
 
@@ -256,7 +267,7 @@ public class StampTourAdminControllerTest {
         @WithMockUser(roles = "ADMIN")
         void 업서트_성공() throws Exception {
             var body = Map.of(
-                    "isStampActivate", true,
+                    "stampActivate", true,
                     "title", "새제목",
                     "authMethod", "TAG_SCAN",
                     "prizeReceiptAuthPassword", "newPw");
@@ -286,6 +297,24 @@ public class StampTourAdminControllerTest {
                             .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isBadRequest())
                     .andDo(StampTourAdminDocs.error("v2-stamptour-basic-upsert-badrequest"));
+        }
+
+        @Test
+        void 업서트_실패_권한없음() throws Exception {
+            var body = Map.of(
+                    "stampActivate", true,
+                    "title", "새제목",
+                    "authMethod", "TAG_SCAN",
+                    "prizeReceiptAuthPassword", "newPw");
+
+            mockMvc.perform(patch(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/basic",
+                                    축제_ID,
+                                    스탬프_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-basic-upsert-unauthorized"));
         }
     }
 
@@ -356,18 +385,7 @@ public class StampTourAdminControllerTest {
         @WithMockUser(roles = "ADMIN")
         void 조회_성공() throws Exception {
             var res = new StampTourLandingPageResDto(
-                    LandingPageDesignTemplate.NONE,
-                    "bg.jpg",
-                    "icon.jpg",
-                    "desc",
-                    ButtonLayout.ONE,
-                    List.of(new ButtonResDto(
-                            0, // sequenceIndex
-                            "바로가기", // content
-                            "icon.png", // iconImgUrl
-                            ButtonAction.OPEN_URL, // action
-                            "https://a.b" // targetUrl
-                            )));
+                    LandingPageDesignTemplate.NONE, "bg.jpg", "icon.jpg", "desc", ButtonLayout.NONE, List.of());
             given(service.getLandingPageSettings(축제_ID, 스탬프_ID)).willReturn(res);
 
             mockMvc.perform(get(
@@ -376,31 +394,47 @@ public class StampTourAdminControllerTest {
                                     스탬프_ID)
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.designTemplate").value("NONE"))
+                    .andExpect(jsonPath("$.landingPageDesignTemplate").value("NONE"))
                     .andDo(StampTourAdminDocs.getLanding());
         }
 
         @Test
         @WithMockUser(roles = "ADMIN")
         void 업서트_성공() throws Exception {
-            var req = Map.of(
-                    "designTemplate", "NONE",
-                    "backgroundImgUrl", "bg.jpg",
-                    "iconImgUrl", "icon.jpg",
-                    "description", "설명",
-                    "buttonLayout", "ONE",
-                    "buttons",
-                            List.of(Map.of(
-                                    "sequenceIndex",
-                                    0,
-                                    "content",
-                                    "바로가기",
-                                    "iconImg",
-                                    "i",
-                                    "action",
-                                    ButtonAction.OPEN_URL.name(),
-                                    "targetUrl",
-                                    "https://a.b")));
+            Map<String, Object> req = new LinkedHashMap<>();
+            req.put("landingPageDesignTemplate", "NONE");
+            req.put("backgroundImgUrl", "bg.jpg");
+            req.put("iconImgUrl", "icon.jpg");
+            req.put("description", "설명");
+            req.put("buttonLayout", "ONE");
+
+            List<Map<String, Object>> buttons = new ArrayList<>();
+
+            Map<String, Object> b1 = new LinkedHashMap<>();
+            b1.put("sequenceIndex", 0);
+            b1.put("content", "바로가기");
+            b1.put("iconImgUrl", "i1.png");
+            b1.put("action", "OPEN_URL"); // enum은 문자열로
+            b1.put("targetUrl", "https://a.b"); // OPEN_URL이면 URL 포함
+            buttons.add(b1);
+
+            Map<String, Object> b2 = new LinkedHashMap<>();
+            b2.put("sequenceIndex", 1);
+            b2.put("content", "QR 스캔");
+            b2.put("iconImgUrl", "i2.png");
+            b2.put("action", "QR_CAMERA");
+            b2.put("targetUrl", null); // 스캔류는 없어도 됨
+            buttons.add(b2);
+
+            Map<String, Object> b3 = new LinkedHashMap<>();
+            b3.put("sequenceIndex", 2);
+            b3.put("content", "새창");
+            b3.put("iconImgUrl", "i3.png");
+            b3.put("action", "OPEN_NEW_PAGE");
+            b3.put("targetUrl", "/info"); // 내부 경로 예시
+            buttons.add(b3);
+
+            req.put("buttons", buttons);
 
             mockMvc.perform(put(
                                     "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/landing",
@@ -412,6 +446,26 @@ public class StampTourAdminControllerTest {
                     .andExpect(status().isOk())
                     .andDo(StampTourAdminDocs.updateLanding());
         }
+
+        @Test
+        void 업서트_실패_권한없음() throws Exception {
+            Map<String, Object> req = new LinkedHashMap<>();
+            req.put("designTemplate", "NONE");
+            req.put("backgroundImgUrl", "bg.jpg");
+            req.put("iconImgUrl", "icon.jpg");
+            req.put("description", "설명");
+            req.put("buttonLayout", "ONE");
+            req.put("buttons", List.of());
+
+            mockMvc.perform(put(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/landing",
+                                    축제_ID,
+                                    스탬프_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-landing-upsert-unauthorized"));
+        }
     }
 
     // ---------------- 메인 ----------------
@@ -421,8 +475,8 @@ public class StampTourAdminControllerTest {
         @Test
         @WithMockUser(roles = "ADMIN")
         void 조회_성공() throws Exception {
-            var res = new StampTourMainPageResDto(
-                    MainPageDesignTemplate.GRID_Nx2, "bg.jpg", ButtonLayout.ONE.name(), List.of());
+            var res =
+                    new StampTourMainPageResDto(MainPageDesignTemplate.GRID_Nx2, "bg.jpg", ButtonLayout.ONE, List.of());
             given(service.getMainPageSettings(축제_ID, 스탬프_ID)).willReturn(res);
 
             mockMvc.perform(get(
@@ -431,7 +485,7 @@ public class StampTourAdminControllerTest {
                                     스탬프_ID)
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.designTemplate").value("GRID_Nx2"))
+                    .andExpect(jsonPath("$.mainPageDesignTemplate").value("GRID_Nx2"))
                     .andDo(StampTourAdminDocs.getMain());
         }
 
@@ -439,7 +493,7 @@ public class StampTourAdminControllerTest {
         @WithMockUser(roles = "ADMIN")
         void 업서트_성공() throws Exception {
             var req = Map.of(
-                    "designTemplate", "GRID_Nx3",
+                    "mainPageDesignTemplate", "GRID_Nx3",
                     "backgroundImgUrl", "bg.jpg",
                     "buttonLayout", "TWO_SYM",
                     "buttons", List.of());
@@ -454,6 +508,24 @@ public class StampTourAdminControllerTest {
                     .andExpect(status().isOk())
                     .andDo(StampTourAdminDocs.updateMain());
         }
+
+        @Test
+        void 업서트_실패_권한없음() throws Exception {
+            var req = Map.of(
+                    "designTemplate", "GRID_Nx3",
+                    "backgroundImgUrl", "bg.jpg",
+                    "buttonLayout", "TWO_SYM",
+                    "buttons", List.of());
+
+            mockMvc.perform(put(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/main",
+                                    축제_ID,
+                                    스탬프_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-main-upsert-unauthorized"));
+        }
     }
 
     // ---------------- 참여가이드 ----------------
@@ -464,7 +536,7 @@ public class StampTourAdminControllerTest {
         @WithMockUser(roles = "ADMIN")
         void 조회_성공() throws Exception {
             var pages = List.of(new ParticipateGuidePageSummaryResDto(페이지_ID, "p1", 1));
-            var res = new StampTourParticipateGuideResDto(1L, GuideDesignTemplate.FULL, GuideSlideMethod.SLIDE, pages);
+            var res = new StampTourParticipateGuideResDto(GuideDesignTemplate.FULL, GuideSlideMethod.SLIDE, pages);
             given(service.getParticipateGuide(축제_ID, 스탬프_ID)).willReturn(res);
 
             mockMvc.perform(get(
@@ -473,7 +545,21 @@ public class StampTourAdminControllerTest {
                                     스탬프_ID)
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.participateGuideId").value(1L))
+                    .andDo(StampTourAdminDocs.getGuide());
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        void 조회_성공_페이지_없음() throws Exception {
+            var res = new StampTourParticipateGuideResDto(GuideDesignTemplate.FULL, GuideSlideMethod.SLIDE, List.of());
+            given(service.getParticipateGuide(축제_ID, 스탬프_ID)).willReturn(res);
+
+            mockMvc.perform(get(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides",
+                                    축제_ID,
+                                    스탬프_ID)
+                            .header(HttpHeaders.AUTHORIZATION, AUTH))
+                    .andExpect(status().isOk())
                     .andDo(StampTourAdminDocs.getGuide());
         }
 
@@ -490,7 +576,7 @@ public class StampTourAdminControllerTest {
         @Test
         @WithMockUser(roles = "ADMIN")
         void 업서트_성공() throws Exception {
-            var req = Map.of("template", "FULL", "method", "SLIDE");
+            var req = new StampTourParticipateGuideReqDto(GuideDesignTemplate.FULL, GuideSlideMethod.SLIDE);
 
             mockMvc.perform(put(
                                     "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides",
@@ -523,6 +609,34 @@ public class StampTourAdminControllerTest {
                     .andExpect(jsonPath("$[0].pageId").value(101L))
                     .andDo(StampTourAdminDocs.updateDisplayOrder());
         }
+
+        @Test
+        void 업서트_실패_권한없음() throws Exception {
+            var req = new StampTourParticipateGuideReqDto(GuideDesignTemplate.FULL, GuideSlideMethod.SLIDE);
+
+            mockMvc.perform(put(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides",
+                                    축제_ID,
+                                    스탬프_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-guide-upsert-unauthorized"));
+        }
+
+        @Test
+        void 순서수정_실패_권한없음() throws Exception {
+            var req = List.of(OrderUpdateRequest.of(101L, 1), OrderUpdateRequest.of(102L, 2));
+
+            mockMvc.perform(patch(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides",
+                                    축제_ID,
+                                    스탬프_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-guide-pages-order-unauthorized"));
+        }
     }
 
     // ---------------- 참여가이드 페이지 ----------------
@@ -532,7 +646,7 @@ public class StampTourAdminControllerTest {
         @Test
         @WithMockUser(roles = "ADMIN")
         void 생성_성공() throws Exception {
-            var req = new StampTourParticipateGuidePageReqDto(1L, "title", MediaSpec.NONE, null, "sum", "det", "add");
+            var req = new StampTourParticipateGuidePageReqDto("title", MediaSpec.NONE, null, "sum", "det", "add");
 
             mockMvc.perform(post(
                                     "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides/pages",
@@ -597,6 +711,53 @@ public class StampTourAdminControllerTest {
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
                     .andExpect(status().isOk())
                     .andDo(StampTourAdminDocs.deleteGuidePage());
+        }
+
+        @Test
+        void 생성_실패_권한없음() throws Exception {
+            var req = new StampTourParticipateGuidePageReqDto("title", MediaSpec.NONE, null, "sum", "det", "add");
+
+            mockMvc.perform(post(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides/pages",
+                                    축제_ID,
+                                    스탬프_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-guide-page-create-unauthorized"));
+        }
+
+        @Test
+        void 수정_실패_권한없음() throws Exception {
+            var req = Map.of(
+                    "guideId", 1L,
+                    "title", "title2",
+                    "mediaSpec", MediaSpec.NONE.name(),
+                    "mediaUrl", "url",
+                    "summary", "s2",
+                    "details", "d2",
+                    "additional", "a2");
+
+            mockMvc.perform(put(
+                                    "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides/pages/{pageId}",
+                                    축제_ID,
+                                    스탬프_ID,
+                                    페이지_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-guide-page-update-unauthorized"));
+        }
+
+        @Test
+        void 삭제_실패_권한없음() throws Exception {
+            mockMvc.perform(delete(
+                            "/api/v2/admin/festivals/{festivalId}/stamp-tours/{stampId}/settings/guides/pages/{pageId}",
+                            축제_ID,
+                            스탬프_ID,
+                            페이지_ID))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(StampTourAdminDocs.error("v2-stamptour-guide-page-delete-unauthorized"));
         }
     }
 }

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/controller/StampTourTemplateControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/controller/StampTourTemplateControllerTest.java
@@ -60,7 +60,7 @@ public class StampTourTemplateControllerTest {
 
             mockMvc.perform(get("/api/v2/template/festivals/{festivalId}/stamp-tours", 축제_ID))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$[0].stampTourId").value(10L))
+                    .andExpect(jsonPath("$[0].stampId").value(10L))
                     .andDo(StampTourTemplateDocs.listStampTours());
         }
     }
@@ -73,8 +73,7 @@ public class StampTourTemplateControllerTest {
             var res = new StampTourSignUpTemplateResDto(JoinVerificationMethod.SMS);
             given(service.getSignupTemplate(축제_ID, 스탬프_ID)).willReturn(res);
 
-            mockMvc.perform(get(
-                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampTourId}/signup", 축제_ID, 스탬프_ID))
+            mockMvc.perform(get("/api/v2/template/festivals/{festivalId}/stamp-tours/{stampId}/signup", 축제_ID, 스탬프_ID))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.joinVerificationMethod").value("SMS"))
                     .andDo(StampTourTemplateDocs.getSignUpTemplate());
@@ -91,10 +90,9 @@ public class StampTourTemplateControllerTest {
                     LandingPageDesignTemplate.NONE, "icon.png", "bg.png", "설명", ButtonLayout.ONE, buttons);
             given(service.getLandingPage(축제_ID, 스탬프_ID)).willReturn(res);
 
-            mockMvc.perform(get(
-                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampTourId}/landing", 축제_ID, 스탬프_ID))
+            mockMvc.perform(get("/api/v2/template/festivals/{festivalId}/stamp-tours/{stampId}/landing", 축제_ID, 스탬프_ID))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.designTemplate").value("NONE"))
+                    .andExpect(jsonPath("$.landingPageDesignTemplate").value("NONE"))
                     .andDo(StampTourTemplateDocs.getLanding());
         }
     }
@@ -108,7 +106,7 @@ public class StampTourTemplateControllerTest {
             given(service.getStampTourJoinMethod(축제_ID, 스탬프_ID)).willReturn(res);
 
             mockMvc.perform(get(
-                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampTourId}/join-template",
+                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampId}/join-template",
                             축제_ID,
                             스탬프_ID))
                     .andExpect(status().isOk())
@@ -126,9 +124,7 @@ public class StampTourTemplateControllerTest {
             given(service.getAuthMethod(축제_ID, 스탬프_ID)).willReturn(res);
 
             mockMvc.perform(get(
-                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampTourId}/auth-method",
-                            축제_ID,
-                            스탬프_ID))
+                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampId}/auth-method", 축제_ID, 스탬프_ID))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.authMethod").value("TAG_SCAN"))
                     .andDo(StampTourTemplateDocs.getAuthMethod());
@@ -143,14 +139,12 @@ public class StampTourTemplateControllerTest {
             var buttons = List.of(
                     new ButtonResDto(0, "QR", "q.png", ButtonAction.QR_CAMERA, null),
                     new ButtonResDto(1, "URL", "u.png", ButtonAction.OPEN_URL, "https://x.y"));
-            var res = new StampTourMainPageResDto(
-                    MainPageDesignTemplate.GRID_Nx2, "bg.png", ButtonLayout.ONE.name(), buttons);
+            var res = new StampTourMainPageResDto(MainPageDesignTemplate.GRID_Nx2, "bg.png", ButtonLayout.ONE, buttons);
             given(service.getMainPage(축제_ID, 스탬프_ID)).willReturn(res);
 
-            mockMvc.perform(get(
-                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampTourId}/main", 축제_ID, 스탬프_ID))
+            mockMvc.perform(get("/api/v2/template/festivals/{festivalId}/stamp-tours/{stampId}/main", 축제_ID, 스탬프_ID))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.designTemplate").value("GRID_Nx2"))
+                    .andExpect(jsonPath("$.mainPageDesignTemplate").value("GRID_Nx2"))
                     .andDo(StampTourTemplateDocs.getMain());
         }
     }
@@ -163,8 +157,7 @@ public class StampTourTemplateControllerTest {
             var res = new StampTourNotificationResDto("주의사항", "개인정보 고지");
             given(service.getStampTourNotification(축제_ID, 스탬프_ID)).willReturn(res);
 
-            mockMvc.perform(get(
-                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampTourId}/notice", 축제_ID, 스탬프_ID))
+            mockMvc.perform(get("/api/v2/template/festivals/{festivalId}/stamp-tours/{stampId}/notice", 축제_ID, 스탬프_ID))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.cautionContent").value("주의사항"))
                     .andDo(StampTourTemplateDocs.getNotice());
@@ -182,8 +175,7 @@ public class StampTourTemplateControllerTest {
             var res = new StampTourGuideResDto(1L, GuideDesignTemplate.FULL, GuideSlideMethod.SLIDE, pages);
             given(service.getParticipateGuide(축제_ID, 스탬프_ID)).willReturn(res);
 
-            mockMvc.perform(get(
-                            "/api/v2/template/festivals/{festivalId}/stamp-tours/{stampTourId}/guide", 축제_ID, 스탬프_ID))
+            mockMvc.perform(get("/api/v2/template/festivals/{festivalId}/stamp-tours/{stampId}/guide", 축제_ID, 스탬프_ID))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.participateGuideId").value(1L))
                     .andExpect(jsonPath("$.participateGuidePages[0].pageId").value(101L))

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/controller/StampTourUserControllerTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/controller/StampTourUserControllerTest.java
@@ -78,10 +78,7 @@ public class StampTourUserControllerTest {
         @Test
         void 성공() throws Exception {
             var body = new StampUserSignupReqDto("홍길동", "010-1111-2222", 2, "추가메모");
-            mockMvc.perform(post(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/signup",
-                                    축제_ID,
-                                    스탬프투어_ID)
+            mockMvc.perform(post("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/signup", 축제_ID, 스탬프투어_ID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isOk())
@@ -92,7 +89,7 @@ public class StampTourUserControllerTest {
         void 실패_검증오류() throws Exception {
             // phone 누락
             var bad = new StampUserLoginDto("홍길동", "");
-            mockMvc.perform(post("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/login", 축제_ID, 스탬프투어_ID)
+            mockMvc.perform(post("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/login", 축제_ID, 스탬프투어_ID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(bad)))
                     .andExpect(status().isBadRequest())
@@ -117,7 +114,7 @@ public class StampTourUserControllerTest {
                     .when(service)
                     .login(eq(축제_ID), eq(스탬프투어_ID), any(StampUserLoginDto.class), any(HttpServletResponse.class));
 
-            mockMvc.perform(post("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/login", 축제_ID, 스탬프투어_ID)
+            mockMvc.perform(post("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/login", 축제_ID, 스탬프투어_ID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(body)))
                     .andExpect(status().isOk())
@@ -129,7 +126,7 @@ public class StampTourUserControllerTest {
         void 실패_검증오류() throws Exception {
             // phone 누락
             var bad = new StampUserLoginDto("홍길동", "");
-            mockMvc.perform(post("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/login", 축제_ID, 스탬프투어_ID)
+            mockMvc.perform(post("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/login", 축제_ID, 스탬프투어_ID)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(bad)))
                     .andExpect(status().isBadRequest())
@@ -158,10 +155,7 @@ public class StampTourUserControllerTest {
 
             given(service.getMissionBoard(eq(축제_ID), eq(스탬프투어_ID), anyString())).willReturn(board);
 
-            mockMvc.perform(get(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/missions",
-                                    축제_ID,
-                                    스탬프투어_ID)
+            mockMvc.perform(get("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/missions", 축제_ID, 스탬프투어_ID)
                             .with(user(스탬프_유저()))
                             .contentType(MediaType.APPLICATION_JSON)
                             .header(HttpHeaders.AUTHORIZATION, AUTH))
@@ -173,8 +167,7 @@ public class StampTourUserControllerTest {
 
         @Test
         void 실패_권한없음() throws Exception {
-            mockMvc.perform(get(
-                            "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/missions", 축제_ID, 스탬프투어_ID))
+            mockMvc.perform(get("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/missions", 축제_ID, 스탬프투어_ID))
                     .andExpect(status().isUnauthorized())
                     .andDo(StampTourUserDocs.error("v2-user-stamptour-mission-board-unauthorized"));
         }
@@ -182,7 +175,7 @@ public class StampTourUserControllerTest {
         @Test
         void 실패_검증오류_PathVariable() throws Exception {
             mockMvc.perform(get(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/missions",
+                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/missions",
                                     축제_ID,
                                     0L) // @Min(1) 위반
                             .with(user(스탬프_유저())))
@@ -219,7 +212,7 @@ public class StampTourUserControllerTest {
             given(service.getMissionsTemplate(eq(축제_ID), eq(스탬프투어_ID), eq(미션_ID), anyString()))
                     .willReturn(res);
             mockMvc.perform(get(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/missions/{missionId}",
+                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/missions/{missionId}",
                                     축제_ID,
                                     스탬프투어_ID,
                                     미션_ID)
@@ -233,7 +226,7 @@ public class StampTourUserControllerTest {
         @Test
         void 실패_권한없음() throws Exception {
             mockMvc.perform(get(
-                            "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/missions/{missionId}",
+                            "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/missions/{missionId}",
                             축제_ID,
                             스탬프투어_ID,
                             미션_ID))
@@ -244,7 +237,7 @@ public class StampTourUserControllerTest {
         @Test
         void 실패_검증오류_PathVariable() throws Exception {
             mockMvc.perform(get(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/missions/{missionId}",
+                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/missions/{missionId}",
                                     축제_ID,
                                     스탬프투어_ID,
                                     0L) // missionId @Min(1) 위반
@@ -267,7 +260,7 @@ public class StampTourUserControllerTest {
             var body = new MissionQrVerifyReqDto(미션_ID);
 
             mockMvc.perform(patch(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/verify/qr",
+                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/verify/qr",
                                     축제_ID,
                                     스탬프투어_ID)
                             .with(user(스탬프_유저()))
@@ -282,7 +275,7 @@ public class StampTourUserControllerTest {
         void 실패_권한없음() throws Exception {
             var body = new MissionQrVerifyReqDto(미션_ID);
             mockMvc.perform(patch(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/verify/qr",
+                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/verify/qr",
                                     축제_ID,
                                     스탬프투어_ID)
                             .contentType(MediaType.APPLICATION_JSON)
@@ -295,7 +288,7 @@ public class StampTourUserControllerTest {
         void 실패_검증오류_PathVariable() throws Exception {
             var body = new MissionQrVerifyReqDto(미션_ID);
             mockMvc.perform(patch(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/verify/qr",
+                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/verify/qr",
                                     축제_ID,
                                     0L) // @Min(1) 위반
                             .with(user(스탬프_유저()))
@@ -321,10 +314,7 @@ public class StampTourUserControllerTest {
             given(service.getPrizeReceiveQr(eq(축제_ID), eq(스탬프투어_ID), anyString()))
                     .willReturn(res);
 
-            mockMvc.perform(get(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/prizes/qr",
-                                    축제_ID,
-                                    스탬프투어_ID)
+            mockMvc.perform(get("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/prizes/qr", 축제_ID, 스탬프투어_ID)
                             .with(user(스탬프_유저()))
                             .header(HttpHeaders.AUTHORIZATION, AUTH)
                             .accept(MediaType.APPLICATION_JSON))
@@ -335,8 +325,7 @@ public class StampTourUserControllerTest {
 
         @Test
         void 실패_권한없음() throws Exception {
-            mockMvc.perform(get(
-                            "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/prizes/qr", 축제_ID, 스탬프투어_ID))
+            mockMvc.perform(get("/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/prizes/qr", 축제_ID, 스탬프투어_ID))
                     .andExpect(status().isUnauthorized())
                     .andDo(StampTourUserDocs.error("v2-user-stamptour-prize-qr-unauthorized"));
         }
@@ -344,7 +333,7 @@ public class StampTourUserControllerTest {
         @Test
         void 실패_검증오류_PathVariable() throws Exception {
             mockMvc.perform(get(
-                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampTourId}/prizes/qr",
+                                    "/api/v2/user/festivals/{festivalId}/stamp-tours/{stampId}/prizes/qr",
                                     축제_ID,
                                     0L) // @Min(1) 위반
                             .with(user(스탬프_유저())))

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/domain/PageTemplateTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/domain/PageTemplateTest.java
@@ -53,7 +53,7 @@ public class PageTemplateTest {
         메인페이지.updateMainPageTemplate(메인페이지_업데이트);
 
         assertThat(메인페이지.getBackgroundImg()).isEqualTo(메인페이지_업데이트.getBackgroundImgUrl());
-        assertThat(메인페이지.getMainPageDesignTemplate()).isEqualTo(메인페이지_업데이트.getDesignTemplate());
+        assertThat(메인페이지.getMainPageDesignTemplate()).isEqualTo(메인페이지_업데이트.getMainPageDesignTemplate());
         assertThat(메인페이지.getButtons().size()).isEqualTo(2);
     }
 

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/domain/StampTourTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/domain/StampTourTest.java
@@ -39,7 +39,7 @@ public class StampTourTest {
     @Test
     void 활성화_전환_성공() {
         스탬프투어1.switchActivation();
-        assertThat(스탬프투어1.isActive()).isFalse();
+        assertThat(스탬프투어1.getActive()).isFalse();
     }
 
     @Test
@@ -50,7 +50,7 @@ public class StampTourTest {
         String 바뀐_관리자_비밀번호 = "pw1234";
         스탬프투어1.changeBasicSettings(비활성화, 바뀐_제목, 바뀐_인증방법, 바뀐_관리자_비밀번호);
         assertThat(스탬프투어1.getTitle()).isEqualTo(바뀐_제목);
-        assertThat(스탬프투어1.isActive()).isEqualTo(비활성화);
+        assertThat(스탬프투어1.getActive()).isEqualTo(비활성화);
         assertThat(스탬프투어1.getAuthMethod()).isEqualTo(바뀐_인증방법);
         assertThat(스탬프투어1.getPrizeReceiptAuthPassword()).isEqualTo(바뀐_관리자_비밀번호);
     }

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/fixture/ParticipateGuidePageFixture.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/fixture/ParticipateGuidePageFixture.java
@@ -124,6 +124,6 @@ public class ParticipateGuidePageFixture {
 
     public static StampTourParticipateGuidePageReqDto 페이지_수정() {
         return new StampTourParticipateGuidePageReqDto(
-                1L, 참여방법_수정_제목, 참여방법_수정_미디어_제공_형식, 참여방법_수정_미디어_url, 참여방법_수정_요약, 참여방법_수정_상세, 참여방법_수정_추가);
+                참여방법_수정_제목, 참여방법_수정_미디어_제공_형식, 참여방법_수정_미디어_url, 참여방법_수정_요약, 참여방법_수정_상세, 참여방법_수정_추가);
     }
 }

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/fixture/StampTourFixture.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/fixture/StampTourFixture.java
@@ -29,10 +29,10 @@ public class StampTourFixture {
     public static AuthMethod 바뀐_스탬프투어_유저인증방법 = AuthMethod.TAG_SCAN;
 
     public static Stamp 스탬프투어1_생성(Festival festival) {
-        return Stamp.createWith(festival, 스탬프투어1_제목);
+        return Stamp.createWith(festival, 스탬프투어1_제목, true);
     }
 
     public static Stamp 스탬프투어2_생성(Festival festival) {
-        return Stamp.createWith(festival, 스탬프투어2_제목);
+        return Stamp.createWith(festival, 스탬프투어2_제목, true);
     }
 }

--- a/src/test/java/com/halo/eventer/domain/stamp/v2/service/StampTourAdminServiceTest.java
+++ b/src/test/java/com/halo/eventer/domain/stamp/v2/service/StampTourAdminServiceTest.java
@@ -131,7 +131,7 @@ public class StampTourAdminServiceTest {
 
         var 결과 = service.getStampTourSettingBasicByFestival(축제_id, 스탬프투어1_ID);
 
-        assertThat(결과.getStampTourId()).isEqualTo(스탬프.getId());
+        assertThat(결과.getStampId()).isEqualTo(스탬프.getId());
         assertThat(결과.getTitle()).isEqualTo(스탬프.getTitle());
     }
 
@@ -160,7 +160,7 @@ public class StampTourAdminServiceTest {
         service.updateBasicSettings(축제_id, 스탬프투어1_ID, 요청);
 
         assertThat(스탬프.getTitle()).isEqualTo(바뀐_스탬프투어_제목);
-        assertThat(스탬프.isActive()).isFalse();
+        assertThat(스탬프.getActive()).isFalse();
         assertThat(스탬프.getPrizeReceiptAuthPassword()).isEqualTo(바뀐_스탬프투어_관리자비번);
         assertThat(스탬프.getAuthMethod()).isEqualTo(바뀐_스탬프투어_유저인증방법);
     }
@@ -237,7 +237,7 @@ public class StampTourAdminServiceTest {
 
         var 결과 = service.getLandingPageSettings(축제_id, 스탬프투어1_ID);
 
-        assertThat(결과.getDesignTemplate()).isEqualTo(LandingPageDesignTemplate.NONE);
+        assertThat(결과.getLandingPageDesignTemplate()).isEqualTo(LandingPageDesignTemplate.NONE);
         then(pageTemplateRepository).should().save(any(PageTemplate.class));
     }
 
@@ -252,7 +252,7 @@ public class StampTourAdminServiceTest {
 
         service.updateLandingPage(축제_id, 스탬프투어1_ID, 요청);
 
-        assertThat(랜딩페이지.getLandingPageDesignTemplate()).isEqualTo(요청.getDesignTemplate());
+        assertThat(랜딩페이지.getLandingPageDesignTemplate()).isEqualTo(요청.getLandingPageDesignTemplate());
         assertThat(랜딩페이지.getBackgroundImg()).isEqualTo(요청.getBackgroundImgUrl());
         assertThat(랜딩페이지.getButtons()).hasSize(2);
     }
@@ -283,7 +283,7 @@ public class StampTourAdminServiceTest {
 
         var 결과 = service.getMainPageSettings(축제_id, 스탬프투어1_ID);
 
-        assertThat(결과.getBackgroundImg()).isEqualTo(메인페이지.getBackgroundImg());
+        assertThat(결과.getBackgroundImgUrl()).isEqualTo(메인페이지.getBackgroundImg());
         assertThat(결과.getButtons()).hasSize(2);
     }
 
@@ -298,7 +298,7 @@ public class StampTourAdminServiceTest {
 
         service.updateMainPageSettings(축제_id, 스탬프투어1_ID, 요청);
 
-        assertThat(메인페이지.getMainPageDesignTemplate()).isEqualTo(요청.getDesignTemplate());
+        assertThat(메인페이지.getMainPageDesignTemplate()).isEqualTo(요청.getMainPageDesignTemplate());
         assertThat(메인페이지.getButtonLayout()).isEqualTo(요청.getButtonLayout());
         assertThat(메인페이지.getButtons()).hasSize(1);
     }
@@ -312,7 +312,6 @@ public class StampTourAdminServiceTest {
 
         var 결과 = service.getParticipateGuide(축제_id, 스탬프투어1_ID);
 
-        assertThat(결과.getParticipateGuideId()).isEqualTo(guide.getId());
         assertThat(결과.getParticipateGuidePages()).hasSize(0);
     }
 
@@ -327,7 +326,6 @@ public class StampTourAdminServiceTest {
         });
         var 결과 = service.getParticipateGuide(축제_id, 스탬프투어1_ID);
         assertThat(결과).isNotNull();
-        assertThat(결과.getParticipateGuideId()).isEqualTo(100L);
         then(participateGuideRepository).should().save(any(ParticipateGuide.class));
     }
 
@@ -386,7 +384,7 @@ public class StampTourAdminServiceTest {
         given(participateGuideRepository.findFirstByStampId(anyLong())).willReturn(Optional.of(guide));
 
         var 요청 = new StampTourParticipateGuidePageReqDto(
-                0L, 참여방법_페이지1_제목, 참여방법_페이지1_미디어_제공_형식, 참여방법_페이지1_미디어_url, 참여방법_페이지1_요약, 참여방법_페이지1_상세, 참여방법_페이지1_추가);
+                참여방법_페이지1_제목, 참여방법_페이지1_미디어_제공_형식, 참여방법_페이지1_미디어_url, 참여방법_페이지1_요약, 참여방법_페이지1_상세, 참여방법_페이지1_추가);
 
         service.createParticipateGuidePage(축제_id, 스탬프투어1_ID, 요청);
 
@@ -425,8 +423,7 @@ public class StampTourAdminServiceTest {
         given(stampRepository.findById(anyLong())).willReturn(Optional.of(스탬프));
         given(participateGuidePageRepository.findById(anyLong())).willReturn(Optional.of(page));
 
-        var 요청 = new StampTourParticipateGuidePageReqDto(
-                0L, "수정제목", 참여방법_페이지3_미디어_제공_형식, "수정URL", "요약수정", "상세수정", "추가수정");
+        var 요청 = new StampTourParticipateGuidePageReqDto("수정제목", 참여방법_페이지3_미디어_제공_형식, "수정URL", "요약수정", "상세수정", "추가수정");
 
         service.updateParticipateGuidePage(축제_id, 스탬프투어1_ID, 300L, 요청);
 
@@ -442,8 +439,7 @@ public class StampTourAdminServiceTest {
         given(stampRepository.findById(anyLong())).willReturn(Optional.of(스탬프));
         given(participateGuidePageRepository.findById(anyLong())).willReturn(Optional.empty());
 
-        var 요청 = new StampTourParticipateGuidePageReqDto(
-                0L, "수정제목", 참여방법_페이지3_미디어_제공_형식, "수정URL", "요약수정", "상세수정", "추가수정");
+        var 요청 = new StampTourParticipateGuidePageReqDto("수정제목", 참여방법_페이지3_미디어_제공_형식, "수정URL", "요약수정", "상세수정", "추가수정");
 
         assertThatThrownBy(() -> service.updateParticipateGuidePage(축제_id, 스탬프투어1_ID, 300L, 요청))
                 .isInstanceOf(ParticipateGuidePageNotFoundException.class);


### PR DESCRIPTION


## #️⃣연관된 이슈

- #173 

## 📝작업 내용

* [feat] 필드명 통일 및 RestDocs 설명 추가

* [feat] 참여 가이드 dto 필드명 수정 및 RestDocs, StampTourAdminControllerTest 수정

* [feat] 랜딩/메인 페이지 디자인 템플릿 필드명 변경

* [feat] 스탬프 미션 관련 필드 수정 및 RestDocs 수정

* [feat] 엔티티 boolean 필드 -> Boolean으로 수정

